### PR TITLE
Updating grammar to respect `fn` keyword

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -26,7 +26,7 @@
     hl = _{ CAPTURE_WS? ~ ( hl_kws  ~ CAPTURE_WS? )* ~ eoi }
         hl_kws = _{ hl_infix | hl_reserved | hl_control | hl_value | hl_call | hl_sym | hl_str | hl_ops | hl_brackets | hl_num | hl_other }
         hl_control = { "if" | "else" | "for" | "while" | "repeat" | "return" }
-        hl_reserved = { "function" }
+        hl_reserved = { "function" | "fn" }
         hl_value = { val_null | val_na | val_inf | val_true | val_false }
         hl_call = _{ hl_callname ~ CAPTURE_WS* ~ hl_open }
         hl_callname = { hl_sym | hl_str }
@@ -128,7 +128,8 @@
 
 // keyworded (kw) syntax
 
-    kw_function = { "function" ~ WS* ~ list ~ WS* ~ expr }
+    kw_function_or_fn = _{ "function" | "fn" }
+    kw_function = { kw_function_or_fn ~ WS* ~ list ~ WS* ~ expr }
     kw_if_else = { "if" ~ WS* ~ "(" ~ WS* ~ expr ~ WS* ~ ")" ~ WS* ~ expr ~ WS* ~ ("else" ~ WS* ~ expr)? }
     kw_for = { "for" ~ WS* ~ "(" ~ WS* ~ symbol ~ WS+ ~ "in" ~ WS+ ~ expr ~ WS* ~ ")" ~ WS* ~ expr }
     kw_while = { "while" ~ WS* ~ "(" ~ WS* ~ expr ~ WS* ~ ")" ~ WS* ~ expr }


### PR DESCRIPTION
Closes #9

Quick fix to include `fn` for function parsing