### PR TITLE
Adding semicolon parsing; parses to { block

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -43,10 +43,11 @@
 
 // repl line feed parsing
 
-    repl = _{ WS* ~ expr ~ WS* ~ eoi }
+    repl = _{ WS* ~ exprs ~ WS* ~ eoi }
 
 // expression basics
 
+    exprs = { expr ~ (WS_NO_NL* ~ ";" ~ WS* ~ expr)* ~ ";"? }
     expr = { atomic ~ WS* ~ ( infix ~ WS* ~ atomic ~ WS* )* }
 
         atomic = _{ prefixed }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -86,6 +86,7 @@ fn parse_primary(pair: Pair<Rule>) -> Expr {
 
         // bracketed expression block
         Rule::block => parse_block(pair),
+        Rule::exprs => parse_block(pair),
         Rule::expr => parse_expr(pair.into_inner()),
 
         // keyworded composite expressions


### PR DESCRIPTION
Adds handling so that `;` can be used to pass multiple commands to the REPL.

**Unlike R**, this does not evaluate each expression in sequence, it instead parses to an AST that is equivalent to a `{` block. This means that the call stack will look slightly different when compared to R. 

This only has an impact at the top level, within any subsequent call, any `;` would be interpreted as part of a block anyways so there shouldn't be a difference. 

I'm undecided on whether this is a feature or a bug. I sort of like that this reduces the problem space a bit, consolidating on a consensus form for representing REPL input, but it would break some compatibility. 