### PR TITLE
Adds call stack evaluation context, primitive `callstack()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,25 +36,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.3"
+name = "bitflags"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -58,51 +73,38 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "js-sys",
- "num-integer",
  "num-traits",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossterm"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -114,10 +116,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm_winapi"
-version = "0.9.0"
+name = "crossterm"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.0",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
@@ -133,54 +151,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -188,19 +162,19 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -215,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.8"
+version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb21c69b9fea5e15dbc1049e4b77145dd0ba1c84019c488102de0dc4ea4b0a27"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
  "rustix",
@@ -226,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -236,42 +210,31 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
-dependencies = [
- "libc",
- "windows-sys",
+ "cc",
 ]
 
 [[package]]
@@ -285,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -300,30 +263,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -331,65 +285,45 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
 dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
+ "windows-sys",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking_lot"
@@ -403,22 +337,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-targets",
 ]
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -426,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.3"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
 dependencies = [
  "pest",
  "pest_generator",
@@ -436,22 +370,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.3"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.3"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
 dependencies = [
  "once_cell",
  "pest",
@@ -460,18 +394,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -480,7 +414,7 @@ dependencies = [
 name = "r"
 version = "0.1.0"
 dependencies = [
- "crossterm",
+ "crossterm 0.27.0",
  "lazy_static",
  "nu-ansi-term",
  "pest",
@@ -494,26 +428,26 @@ name = "r_derive"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "reedline"
-version = "0.14.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d91d2a38dbdaf0c748a96055c14aa4746be9add5f4aea4b1460e6e6492f770"
+checksum = "c2fde955d11817fdcb79d703932fb6b473192cb36b6a92ba21f7f4ac0513374e"
 dependencies = [
  "chrono",
- "crossterm",
+ "crossterm 0.26.1",
  "fd-lock",
  "itertools",
  "nu-ansi-term",
@@ -528,13 +462,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys",
@@ -542,47 +475,41 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -591,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -612,18 +539,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -636,28 +563,28 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -665,43 +592,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
+name = "syn"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
- "winapi-util",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -712,21 +630,21 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -736,9 +654,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"
@@ -769,21 +687,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -791,24 +703,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -816,22 +728,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "winapi"
@@ -850,25 +762,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.42.0"
+name = "windows"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -881,42 +802,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossterm = "0.24.0"
+crossterm = "0.27.0"
 lazy_static = "1.4.0"
-nu-ansi-term = "0.46.0"
 pest = "2.5.2"
 pest_derive = "2.5.2"
-reedline = "0.14.0"
+reedline = "0.22.0"
+nu-ansi-term = "0.49.0"
 r_derive = { path = "r_derive" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::parser::*;
+use crate::{parser::*, lang::CallStack};
 
 use core::fmt;
 use pest::error::LineColLocation::Pos;
@@ -15,14 +15,16 @@ pub enum RError {
     CannotBeCoercedToLogical,
     CannotBeCoercedToInteger,
 
+    // temporary workaround until we propagate call stack to all error locations
+    WithCallStack(Box<RError>, CallStack),  
     Other(String),
 }
 
 impl RError {
     fn as_str(&self) -> String {
         match self {
-            RError::IncorrectContext(x) => format!("Error: '{}' used in an incorrect context", x),
-            RError::VariableNotFound(v) => format!("Error: object '{}' not found", v.as_str()),
+            RError::IncorrectContext(x) => format!("'{}' used in an incorrect context", x),
+            RError::VariableNotFound(v) => format!("object '{}' not found", v.as_str()),
             RError::ParseFailureVerbose(e) => format!("{}", e),
             RError::ParseFailure(e) => match e.line_col {
                 Pos((line, col)) => format!("Parse failed at Line {}, Column {}", line, col),
@@ -46,12 +48,13 @@ impl RError {
             RError::Other(s) => {
                 format!("{}", s)
             }
+            RError::WithCallStack(e, c) => format!("{}\n{c}", e.as_str()),
         }
     }
 }
 
 impl fmt::Display for RError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        write!(f, "Error: {}", self.as_str())
     }
 }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -43,7 +43,7 @@
 
 // repl line feed parsing
 
-    repl = _{ WS* ~ exprs ~ WS* ~ eoi }
+    repl = _{ WS* ~ expr ~ WS* ~ eoi | WS* ~ exprs ~ WS* ~ eoi }
 
 // expression basics
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -52,13 +52,8 @@ impl R {
         match self {
             R::Closure(expr, env) => {
                 stack.add_frame(expr.clone(), env);
-                match stack.eval(expr) {
-                    result @ Ok(..) => {
-                        stack.frames.pop();
-                        result
-                    },
-                    error => error,
-                }
+                let result = stack.eval(expr);
+                stack.pop_frame_after(result)
             },
             _ => Ok(self),
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,7 +51,6 @@ pub fn parse_args(s: &str) -> Result<ExprList, RError> {
 }
 
 fn parse_expr(pairs: Pairs<Rule>) -> Expr {
-    // println!("{:#?}", pairs);
     PRATT_PARSER
         .map_primary(parse_primary)
         .map_infix(|lhs, op, rhs| {

--- a/src/r_builtins/builtins.rs
+++ b/src/r_builtins/builtins.rs
@@ -1,17 +1,15 @@
 extern crate r_derive;
 use r_derive::*;
 
+use super::paste::*;
 use crate::ast::*;
 use crate::lang::*;
 use crate::r_vector::vectors::*;
 
-use super::paste::*;
-use std::rc::Rc;
-
 fn match_args(
     mut formals: ExprList,
     mut args: Vec<(Option<String>, R)>,
-    env: &Environment,
+    stack: &CallStack,
 ) -> (Vec<(Option<String>, R)>, Vec<(Option<String>, R)>) {
     let mut ellipsis: Vec<(Option<String>, R)> = vec![];
     let mut matched_args: Vec<(Option<String>, R)> = vec![];
@@ -56,7 +54,7 @@ fn match_args(
 
     // add back in parameter defaults that weren't filled with args
     for (param, default) in formals.into_iter() {
-        matched_args.push((param, R::Closure(default, Rc::clone(env))));
+        matched_args.push((param, R::Closure(default, stack.last_frame().env.clone())));
     }
 
     (matched_args, ellipsis)
@@ -85,11 +83,11 @@ pub trait CallableClone: Callable {
 }
 
 pub trait Callable {
-    fn call_assign(&self, _value: Expr, _args: ExprList, _env: &mut Environment) -> EvalResult {
+    fn call_assign(&self, _value: Expr, _args: ExprList, _stack: &mut CallStack) -> EvalResult {
         unimplemented!();
     }
 
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult;
 }
 
 pub struct FormatState {
@@ -181,16 +179,15 @@ impl Format for PrimIf {
 }
 
 impl Callable for PrimIf {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut args = args.values.into_iter();
-
-        let cond = env.eval(args.next().unwrap())?;
+        let cond = stack.eval(args.next().unwrap())?;
         let cond: bool = cond.try_into()?;
 
         if cond {
-            env.eval(args.next().unwrap())
+            stack.eval(args.next().unwrap())
         } else {
-            env.eval(args.skip(1).next().unwrap_or(Expr::Null))
+            stack.eval(args.skip(1).next().unwrap_or(Expr::Null))
         }
     }
 }
@@ -209,7 +206,7 @@ impl Format for PrimFor {
 }
 
 impl Callable for PrimFor {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut args = args.into_iter();
 
         let (Some(var), iter_expr) = args.next().unwrap() else {
@@ -217,7 +214,7 @@ impl Callable for PrimFor {
         };
 
         let (_, body) = args.next().unwrap();
-        let iter = env.eval(iter_expr)?;
+        let iter = stack.eval(iter_expr)?;
 
         let mut eval_result: EvalResult;
         let mut result = R::Null;
@@ -226,8 +223,8 @@ impl Callable for PrimFor {
         while let Some(value) = iter.get(index) {
             index += 1;
 
-            env.insert(var.clone(), value);
-            eval_result = env.eval(body.clone());
+            stack.last_frame().env.insert(var.clone(), value);
+            eval_result = stack.eval(body.clone());
 
             use Cond::*;
             use RSignal::*;
@@ -256,11 +253,12 @@ impl Format for PrimWhile {
 }
 
 impl Callable for PrimWhile {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         use Cond::*;
         use RSignal::*;
 
         let mut args = args.values.into_iter();
+
         let cond = args.next().unwrap();
         let body = args.next().unwrap();
 
@@ -269,9 +267,9 @@ impl Callable for PrimWhile {
 
         loop {
             // handle while condition
-            let cond_result = env.eval(cond.clone())?;
+            let cond_result = stack.eval(cond.clone())?;
             if cond_result.try_into()? {
-                eval_result = env.eval(body.clone());
+                eval_result = stack.eval(body.clone());
             } else {
                 break;
             }
@@ -303,7 +301,7 @@ impl Format for PrimRepeat {
 }
 
 impl Callable for PrimRepeat {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut args = args.values.into_iter();
         let body = args.next().unwrap();
 
@@ -311,7 +309,7 @@ impl Callable for PrimRepeat {
         let mut result = R::Null;
 
         loop {
-            eval_result = env.eval(body.clone());
+            eval_result = stack.eval(body.clone());
 
             // handle control flow signals during execution
             match eval_result {
@@ -347,10 +345,10 @@ impl Format for PrimBlock {
 }
 
 impl Callable for PrimBlock {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut value = Ok(R::Null);
         for expr in args.values {
-            let result = env.eval(expr);
+            let result = stack.eval(expr);
             match result {
                 Ok(_) => value = result,
                 _ => return result,
@@ -368,22 +366,22 @@ impl Op for InfixAssign {
 }
 
 impl Callable for InfixAssign {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = args.unnamed_binary_args();
 
         use Expr::*;
         match lhs {
             String(s) | Symbol(s) => {
-                let value = env.eval(rhs)?;
-                env.insert(s, value.clone());
+                let value = stack.eval(rhs)?;
+                stack.last_frame().env.insert(s, value.clone());
                 Ok(value)
             }
             Call(what, mut args) => match *what {
-                Primitive(prim) => prim.call_assign(rhs, args, env),
+                Primitive(prim) => prim.call_assign(rhs, args, stack),
                 String(s) | Symbol(s) => {
                     args.insert(0, rhs);
                     let s = format!("{}<-", s);
-                    env.eval(Call(Box::new(Symbol(s)), args))
+                    stack.eval(Call(Box::new(Symbol(s)), args))
                 }
                 _ => unreachable!(),
             },
@@ -400,8 +398,8 @@ impl Op for InfixAdd {
 }
 
 impl Callable for InfixAdd {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs + rhs
     }
 }
@@ -414,8 +412,8 @@ impl Op for InfixSub {
 }
 
 impl Callable for InfixSub {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs - rhs
     }
 }
@@ -430,8 +428,8 @@ impl Format for PrefixSub {
 }
 
 impl Callable for PrefixSub {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let what = env.eval(args.unnamed_unary_arg())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let what = stack.eval(args.unnamed_unary_arg())?;
         -what
     }
 }
@@ -444,8 +442,8 @@ impl Op for InfixMul {
 }
 
 impl Callable for InfixMul {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs * rhs
     }
 }
@@ -458,8 +456,8 @@ impl Op for InfixDiv {
 }
 
 impl Callable for InfixDiv {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs / rhs
     }
 }
@@ -472,8 +470,8 @@ impl Op for InfixPow {
 }
 
 impl Callable for InfixPow {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs.power(rhs)
     }
 }
@@ -486,8 +484,8 @@ impl Op for InfixMod {
 }
 
 impl Callable for InfixMod {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs % rhs
     }
 }
@@ -500,8 +498,8 @@ impl Op for InfixOr {
 }
 
 impl Callable for InfixOr {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         let res = match (lhs, rhs) {
             (R::Vector(l), R::Vector(r)) => {
                 let Ok(lhs) = l.try_into() else { todo!() };
@@ -523,8 +521,8 @@ impl Op for InfixAnd {
 }
 
 impl Callable for InfixAnd {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         let res = match (lhs, rhs) {
             (R::Vector(l), R::Vector(r)) => {
                 let Ok(lhs) = l.try_into() else { todo!() };
@@ -546,8 +544,8 @@ impl Op for InfixVectorOr {
 }
 
 impl Callable for InfixVectorOr {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs | rhs
     }
 }
@@ -560,8 +558,8 @@ impl Op for InfixVectorAnd {
 }
 
 impl Callable for InfixVectorAnd {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs & rhs
     }
 }
@@ -574,8 +572,8 @@ impl Op for InfixGreater {
 }
 
 impl Callable for InfixGreater {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs.vec_gt(rhs)
     }
 }
@@ -588,8 +586,8 @@ impl Op for InfixGreaterEqual {
 }
 
 impl Callable for InfixGreaterEqual {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs.vec_gte(rhs)
     }
 }
@@ -602,8 +600,8 @@ impl Op for InfixLess {
 }
 
 impl Callable for InfixLess {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs.vec_lt(rhs)
     }
 }
@@ -616,8 +614,8 @@ impl Op for InfixLessEqual {
 }
 
 impl Callable for InfixLessEqual {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs.vec_lte(rhs)
     }
 }
@@ -630,8 +628,8 @@ impl Op for InfixEqual {
 }
 
 impl Callable for InfixEqual {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs.vec_eq(rhs)
     }
 }
@@ -644,8 +642,8 @@ impl Op for InfixNotEqual {
 }
 
 impl Callable for InfixNotEqual {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (lhs, rhs) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
         lhs.vec_neq(rhs)
     }
 }
@@ -658,7 +656,7 @@ impl Op for InfixPipe {
 }
 
 impl Callable for InfixPipe {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         // TODO: reduce call stack nesting here
         let (lhs, rhs) = args.unnamed_binary_args();
 
@@ -667,7 +665,7 @@ impl Callable for InfixPipe {
             Call(what, mut args) => {
                 args.insert(0, lhs);
                 let new_expr = Call(what, args);
-                env.eval(new_expr)
+                stack.eval(new_expr)
             }
             _ => unreachable!(),
         }
@@ -691,14 +689,14 @@ impl Format for PostfixIndex {
 }
 
 impl Callable for PostfixIndex {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (what, index) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (what, index) = stack.eval_binary(args.unnamed_binary_args())?;
         what.try_get(index)
     }
 
-    fn call_assign(&self, value: Expr, args: ExprList, env: &mut Environment) -> EvalResult {
-        let value = env.eval(value)?;
-        let (what, index) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call_assign(&self, value: Expr, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let value = stack.eval(value)?;
+        let (what, index) = stack.eval_binary(args.unnamed_binary_args())?;
 
         use R::*;
         match (what, value, index.as_integer()?) {
@@ -721,8 +719,8 @@ impl Format for PostfixVecIndex {
 }
 
 impl Callable for PostfixVecIndex {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
-        let (what, index) = env.eval_binary(args.unnamed_binary_args())?;
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (what, index) = stack.eval_binary(args.unnamed_binary_args())?;
         what.try_get(index)
     }
 }
@@ -737,9 +735,9 @@ impl Format for PrimVec {
 }
 
 impl Callable for PrimVec {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         // for now just use c()
-        primitive_c(args, env)
+        primitive_c(args, stack)
     }
 }
 
@@ -753,10 +751,10 @@ impl Format for PrimList {
 }
 
 impl Callable for PrimList {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let vals: Result<Vec<_>, _> = args
             .into_iter()
-            .map(|(n, v)| match env.eval(v) {
+            .map(|(n, v)| match stack.eval(v) {
                 Ok(val) => Ok((n, val)),
                 Err(err) => Err(err),
             })
@@ -769,7 +767,7 @@ impl Callable for PrimList {
 #[derive(Debug, Clone)]
 pub struct Name(String);
 
-pub fn primitive(name: &str) -> Option<Box<dyn Fn(ExprList, &mut Environment) -> EvalResult>> {
+pub fn primitive(name: &str) -> Option<Box<dyn Fn(ExprList, &mut CallStack) -> EvalResult>> {
     match name {
         "c" => Some(Box::new(primitive_c)),
         "list" => Some(Box::new(primitive_list)),
@@ -779,12 +777,12 @@ pub fn primitive(name: &str) -> Option<Box<dyn Fn(ExprList, &mut Environment) ->
     }
 }
 
-pub fn primitive_q(_args: ExprList, _env: &mut Environment) -> EvalResult {
+pub fn primitive_q(_args: ExprList, _stack: &mut CallStack) -> EvalResult {
     Err(RSignal::Condition(Cond::Terminate))
 }
 
-pub fn primitive_list(args: ExprList, env: &mut Environment) -> EvalResult {
-    PrimList::call(&PrimList, args, env)
+pub fn primitive_list(args: ExprList, stack: &mut CallStack) -> EvalResult {
+    PrimList::call(&PrimList, args, stack)
 }
 
 pub fn force_closures(vals: Vec<(Option<String>, R)>) -> Vec<(Option<String>, R)> {
@@ -795,11 +793,11 @@ pub fn force_closures(vals: Vec<(Option<String>, R)>) -> Vec<(Option<String>, R)
         .collect()
 }
 
-pub fn primitive_c(args: ExprList, env: &mut Environment) -> EvalResult {
+pub fn primitive_c(args: ExprList, stack: &mut CallStack) -> EvalResult {
     // this can be cleaned up quite a bit, but I just need it working with
     // more types for now to test vectorized operators using different types
 
-    let R::List(vals) = env.eval_list(args)? else {
+    let R::List(vals) = stack.eval_list(args)? else {
         unreachable!()
     };
 
@@ -906,42 +904,40 @@ impl Format for String {
 }
 
 impl Callable for String {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         if let Some(f) = primitive(self) {
-            return f(args, env);
+            return f(args, stack);
         }
 
-        (env.get(self.clone())?).call(args, env)
+        (stack.last_frame().env.get(self.clone())?).call(args, stack)
     }
 }
 
 impl Format for R {}
 
 impl Callable for R {
-    fn call(&self, args: ExprList, env: &mut Environment) -> EvalResult {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let R::Function(formals, body, fn_env) = self else {
             unimplemented!("can't call non-function")
         };
 
         // set up our local scope, a child environment of the function environment
-        let mut local_scope = Environment::new(Env {
-            parent: Some(Rc::clone(fn_env)),
-            ..Default::default()
-        });
+        let mut local_frame = stack.last_frame();
+        let mut local_env = local_frame.env;
 
         // evaluate arguments in calling environment
-        let R::List(args) = env.eval_list(args)? else {
+        let R::List(args) = stack.eval_list(args)? else {
             unreachable!();
         };
 
         // match arguments against function signature
-        let (args, ellipsis) = match_args(formals.clone(), args, env);
+        let (args, ellipsis) = match_args(formals.clone(), args, stack);
 
         // add closures to local scope
-        local_scope.insert("...".to_string(), R::List(ellipsis));
-        local_scope.append(R::List(args));
+        local_env.insert("...".to_string(), R::List(ellipsis));
+        local_env.append(R::List(args));
 
         // evaluate body in local scope
-        local_scope.eval(body.clone())
+        local_frame.eval(body.clone())
     }
 }

--- a/src/r_builtins/callstack.rs
+++ b/src/r_builtins/callstack.rs
@@ -1,0 +1,11 @@
+use crate::ast::ExprList;
+use crate::lang::{CallStack, EvalResult, R};
+
+pub fn primitive_callstack(_: ExprList, stack: &mut CallStack) -> EvalResult {
+    Ok(R::List(
+        stack.frames.iter()
+            .skip(1)
+            .map(|f| (None, R::Expr(f.call.clone())))
+            .collect()
+    ))
+}

--- a/src/r_builtins/mod.rs
+++ b/src/r_builtins/mod.rs
@@ -4,3 +4,4 @@
 ///
 pub mod builtins;
 pub mod paste;
+pub mod callstack;

--- a/src/r_builtins/paste.rs
+++ b/src/r_builtins/paste.rs
@@ -4,8 +4,8 @@ use crate::lang::*;
 use crate::r_builtins::builtins::force_closures;
 use crate::r_vector::vectors::*;
 
-pub fn primitive_paste(args: ExprList, env: &mut Environment) -> EvalResult {
-    let R::List(vals) = env.eval_list(args)? else {
+pub fn primitive_paste(args: ExprList, stack: &mut CallStack) -> EvalResult {
+    let R::List(vals) = stack.eval_list(args)? else {
         unreachable!()
     };
 

--- a/src/r_builtins/paste.rs
+++ b/src/r_builtins/paste.rs
@@ -9,8 +9,7 @@ pub fn primitive_paste(args: ExprList, stack: &mut CallStack) -> EvalResult {
         unreachable!()
     };
 
-    let mut vals = force_closures(vals);
-
+    let mut vals = force_closures(vals, stack);
     let mut sep = String::from(" ");
     let mut should_collapse = false;
     let mut collapse = String::new();
@@ -43,8 +42,9 @@ pub fn primitive_paste(args: ExprList, stack: &mut CallStack) -> EvalResult {
                 collapse = v.get(0).unwrap().clone().to_string();
             }
             ("collapse", _) => {
-                return Err(RSignal::Error(RError::Other(
-                    "collapse parameter must be NULL or a character string.".to_string(),
+                return Err(RSignal::Error(RError::WithCallStack(
+                    Box::new(RError::Other("collapse parameter must be NULL or a character string.".to_string())),
+                    stack.clone()
                 )))
             }
             _ => continue,

--- a/src/r_repl/highlight.rs
+++ b/src/r_repl/highlight.rs
@@ -1,4 +1,5 @@
-use nu_ansi_term::{Color, Style};
+use nu_ansi_term::Style;
+use nu_ansi_term::Color;
 use reedline::Highlighter;
 use reedline::StyledText;
 

--- a/src/r_repl/prompt.rs
+++ b/src/r_repl/prompt.rs
@@ -1,8 +1,7 @@
 use std::borrow::Cow;
 
-use crossterm::style::Color;
 use reedline::{
-    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
+    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode, Color
 };
 
 #[derive(Clone)]

--- a/src/r_repl/repl.rs
+++ b/src/r_repl/repl.rs
@@ -1,9 +1,11 @@
 use reedline::{FileBackedHistory, Reedline, Signal};
 use std::path::Path;
+use std::rc::Rc;
 
 use super::highlight::RHighlighter;
 use super::prompt::RPrompt;
 use super::validator::RValidator;
+use crate::ast::Expr;
 use crate::lang::{CallStack, Cond, Context, Environment, Frame, RSignal};
 use crate::parser::parse;
 
@@ -22,7 +24,7 @@ where
         println!("Restoring session history...");
 
         let history = Box::new(
-            FileBackedHistory::with_file(5, "/tmp/history.txt".into())
+            FileBackedHistory::with_file(1000, "/tmp/history.txt".into())
                 .expect("Error configuring history with file"),
         );
 
@@ -35,7 +37,7 @@ where
     let prompt = RPrompt::default();
 
     // start session environment
-    let mut global_env = Environment::default();
+    let global_env = Rc::new(Environment::default());
 
     // REPL
     loop {
@@ -51,12 +53,12 @@ where
                 let parse_res = parse(&line);
                 match parse_res {
                     Ok(expr) => {
-                        // start a new callstack for this expression
-                        let mut stack = CallStack::from(Frame::new(expr, global_env));
+                        // start new callstack for input, starting with a missing at the global env 
+                        let mut stack = CallStack::from(Frame { call: Expr::Missing, env: global_env.clone() });
                         let res = stack.eval(expr);
                         match res {
-                            Ok(val) => println!("{}", val),
                             Err(RSignal::Condition(Cond::Terminate)) => break,
+                            Ok(val) => println!("{}", val),
                             Err(e) => println!("{}", e),
                         }
                     }

--- a/src/r_repl/repl.rs
+++ b/src/r_repl/repl.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use super::highlight::RHighlighter;
 use super::prompt::RPrompt;
 use super::validator::RValidator;
-use crate::lang::{Cond, Context, Environment, RSignal};
+use crate::lang::{CallStack, Cond, Context, Environment, Frame, RSignal};
 use crate::parser::parse;
 
 pub fn repl<P>(history: Option<&P>) -> Result<(), ()>
@@ -51,7 +51,9 @@ where
                 let parse_res = parse(&line);
                 match parse_res {
                     Ok(expr) => {
-                        let res = global_env.eval(expr);
+                        // start a new callstack for this expression
+                        let mut stack = CallStack::from(Frame::new(expr, global_env));
+                        let res = stack.eval(expr);
                         match res {
                             Ok(val) => println!("{}", val),
                             Err(RSignal::Condition(Cond::Terminate)) => break,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,13 +32,6 @@ pub fn eval(expr: RExpr, env: &mut Environment) -> EvalResult {
     }
 }
 
-pub fn force(val: R) -> EvalResult {
-    match val {
-        R::Closure(expr, mut env) => eval(expr, &mut env),
-        _ => Ok(val),
-    }
-}
-
 pub fn eval_rexprlist(x: RExprList, env: &mut Environment) -> EvalResult {
     Ok(R::List(
         x.into_iter()


### PR DESCRIPTION
### Core Changes

- Adds a `CallStack` structure which implements the `Context` trait, adding frames (with new local function body environments) when calls are made
- Adds a `callstack()` primitive - I couldn't bring myself to name it `"sys.calls"` (what is `sys` anyways?), but that's effectively what it is.
- Filling in a few gaps for displaying objects, namely for closures and environments for debugging

And it looks something like this:

```r
> x <- function(...) paste(...)
> y <- function(...) x(...)
> z <- function(...) y(...)
> z('a', c('b', 'c'), collapse = 3)
# Error: collapse parameter must be NULL or a character string.
# 1: z("a", c("b", "c"), collapse = 3) <environment 0x56413d9daa28>
# 2: y(...) <environment 0x56413d9db738>
# 3: x(...) <environment 0x56413d9db668>
# 4: paste(...) <environment 0x56413d9db668>
```

_currently this is the only error that surfaces a traceback automatically, just to test out the feature_

### Chores

- Bring some dependencies up-to-date
- Allow parser to parse single expressions without adding extra `{ ... }` wrapping primitive