### PR TITLE
Implementing PartialEq; adding assert_r_eq! macro

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -23,6 +23,35 @@ pub enum Expr {
     Primitive(Box<dyn Primitive>),
 }
 
+impl PartialEq for Expr {
+    fn eq(&self, other: &Self) -> bool {
+        use Expr::*;
+        match (self, other) {
+            (Null, Null) => true,
+            (NA, NA) => true,
+            (Inf, Inf) => true,
+            (Continue, Continue) => true,
+            (Break, Break) => true,
+            (Ellipsis, Ellipsis) => true,
+            (Missing, Missing) => true,
+            (Bool(l), Bool(r)) => l == r,
+            (Number(l), Number(r)) => l == r,
+            (Integer(l), Integer(r)) => l == r,
+            (String(l), String(r)) => l == r,
+            (Symbol(l), Symbol(r)) => l == r,
+            (List(l), List(r)) => l == r,
+            (Primitive(l), Primitive(r)) => l == r,
+            (Function(largs, lbody), Function(rargs, rbody)) => {
+                largs == rargs && lbody == rbody
+            },
+            (Call(lwhat, largs), Call(rwhat, rargs)) => {
+                lwhat == rwhat && largs == rargs
+            },
+            _ => false
+        }
+    }
+}
+
 impl Expr {
     pub fn as_primitive<T>(x: T) -> Self
     where
@@ -64,7 +93,7 @@ impl fmt::Display for Expr {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ExprList {
     pub keys: Vec<Option<String>>, // TODO: use Vec<RExprListKey>
     pub values: Vec<Expr>,

--- a/src/callable/core.rs
+++ b/src/callable/core.rs
@@ -3,6 +3,7 @@ extern crate r_derive;
 use std::rc::Rc;
 use crate::ast::*;
 use crate::callable::operators::*;
+use crate::callable::dyncompare::*;
 use crate::lang::*;
 
 fn match_args(
@@ -146,7 +147,13 @@ pub trait Format {
     }
 }
 
-pub trait Primitive: Callable + CallableClone + Format {
+pub trait Primitive: Callable + CallableClone + Format + DynCompare {
+}
+
+impl PartialEq<dyn Primitive> for dyn Primitive {
+    fn eq(&self, other: &dyn Primitive) -> bool {
+        self.as_dyn_compare() == other.as_dyn_compare()
+    }
 }
 
 pub trait PrimitiveSYM {

--- a/src/callable/dyncompare.rs
+++ b/src/callable/dyncompare.rs
@@ -1,0 +1,40 @@
+// From 'Learning Rust' "dyn PartialEq"
+
+use std::any::Any;
+
+pub trait AsDynCompare: Any {
+    fn as_any(&self) -> &dyn Any;
+    fn as_dyn_compare(&self) -> &dyn DynCompare;
+}
+
+impl<T: Any + DynCompare> AsDynCompare for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_dyn_compare(&self) -> &dyn DynCompare {
+        self
+    }
+}
+
+pub trait DynCompare: AsDynCompare {
+    fn dyn_eq(&self, other: &dyn DynCompare) -> bool;
+}
+
+impl<T: Any + PartialEq> DynCompare for T {
+    fn dyn_eq(&self, other: &dyn DynCompare) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<Self>() {
+            self == other
+        } else {
+            false
+        }
+    }
+}
+
+// n.b. this could be implemented in a more general way when
+// the trait object lifetime is not constrained to `'static`
+impl PartialEq<dyn DynCompare> for dyn DynCompare {
+    fn eq(&self, other: &dyn DynCompare) -> bool {
+        self.dyn_eq(other)
+    }
+}
+

--- a/src/callable/keywords.rs
+++ b/src/callable/keywords.rs
@@ -4,7 +4,7 @@ use crate::ast::*;
 use crate::lang::*;
 use super::core::*;
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimIf;
 
 impl Format for PrimIf {
@@ -34,7 +34,7 @@ impl Callable for PrimIf {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimFor;
 
 impl Format for PrimFor {
@@ -85,7 +85,7 @@ impl Callable for PrimFor {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimWhile;
 
 impl Format for PrimWhile {
@@ -133,7 +133,7 @@ impl Callable for PrimWhile {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimRepeat;
 
 impl Format for PrimRepeat {
@@ -170,7 +170,7 @@ impl Callable for PrimRepeat {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimBlock;
 
 impl Format for PrimBlock {

--- a/src/callable/mod.rs
+++ b/src/callable/mod.rs
@@ -1,4 +1,6 @@
 pub mod core;
+pub mod dyncompare;
+
 pub mod primitive;
 pub mod keywords;
 pub mod operators;

--- a/src/callable/operators.rs
+++ b/src/callable/operators.rs
@@ -5,7 +5,7 @@ use crate::lang::*;
 use crate::vector::vectors::*;
 use super::core::*;
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixAssign;
 
 impl PrimitiveSYM for InfixAssign {
@@ -37,7 +37,7 @@ impl Callable for InfixAssign {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixAdd;
 
 impl PrimitiveSYM for InfixAdd {
@@ -51,7 +51,7 @@ impl Callable for InfixAdd {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixSub;
 
 impl PrimitiveSYM for InfixSub {
@@ -65,7 +65,7 @@ impl Callable for InfixSub {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrefixSub;
 
 impl Format for PrefixSub {
@@ -81,7 +81,7 @@ impl Callable for PrefixSub {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixMul;
 
 impl PrimitiveSYM for InfixMul {
@@ -95,7 +95,7 @@ impl Callable for InfixMul {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixDiv;
 
 impl PrimitiveSYM for InfixDiv {
@@ -109,7 +109,7 @@ impl Callable for InfixDiv {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixPow;
 
 impl PrimitiveSYM for InfixPow {
@@ -123,7 +123,7 @@ impl Callable for InfixPow {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixMod;
 
 impl PrimitiveSYM for InfixMod {
@@ -137,7 +137,7 @@ impl Callable for InfixMod {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixOr;
 
 impl PrimitiveSYM for InfixOr {
@@ -160,7 +160,7 @@ impl Callable for InfixOr {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixAnd;
 
 impl PrimitiveSYM for InfixAnd {
@@ -183,7 +183,7 @@ impl Callable for InfixAnd {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixVectorOr;
 
 impl PrimitiveSYM for InfixVectorOr {
@@ -197,7 +197,7 @@ impl Callable for InfixVectorOr {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixVectorAnd;
 
 impl PrimitiveSYM for InfixVectorAnd {
@@ -211,7 +211,7 @@ impl Callable for InfixVectorAnd {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixGreater;
 
 impl PrimitiveSYM for InfixGreater {
@@ -225,7 +225,7 @@ impl Callable for InfixGreater {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixGreaterEqual;
 
 impl PrimitiveSYM for InfixGreaterEqual {
@@ -239,7 +239,7 @@ impl Callable for InfixGreaterEqual {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixLess;
 
 impl PrimitiveSYM for InfixLess {
@@ -253,7 +253,7 @@ impl Callable for InfixLess {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixLessEqual;
 
 impl PrimitiveSYM for InfixLessEqual {
@@ -267,7 +267,7 @@ impl Callable for InfixLessEqual {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixEqual;
 
 impl PrimitiveSYM for InfixEqual {
@@ -281,7 +281,7 @@ impl Callable for InfixEqual {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixNotEqual;
 
 impl PrimitiveSYM for InfixNotEqual {
@@ -295,7 +295,7 @@ impl Callable for InfixNotEqual {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct InfixPipe;
 
 impl PrimitiveSYM for InfixPipe {
@@ -324,7 +324,7 @@ impl Callable for InfixPipe {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PostfixIndex;
 
 impl Format for PostfixIndex {
@@ -361,7 +361,7 @@ impl Callable for PostfixIndex {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PostfixVecIndex;
 
 impl Format for PostfixVecIndex {
@@ -377,7 +377,7 @@ impl Callable for PostfixVecIndex {
     }
 }
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimVec;
 
 impl Format for PrimVec {

--- a/src/callable/primitive/c.rs
+++ b/src/callable/primitive/c.rs
@@ -5,7 +5,7 @@ use crate::lang::*;
 use crate::vector::vectors::*;
 use crate::callable::core::*;
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimitiveC;
 
 impl PrimitiveSYM for PrimitiveC {

--- a/src/callable/primitive/callstack.rs
+++ b/src/callable/primitive/callstack.rs
@@ -4,7 +4,7 @@ use crate::ast::ExprList;
 use crate::lang::{CallStack, EvalResult, R};
 use crate::callable::core::*;
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimitiveCallstack;
 
 impl PrimitiveSYM for PrimitiveCallstack {

--- a/src/callable/primitive/list.rs
+++ b/src/callable/primitive/list.rs
@@ -4,7 +4,7 @@ use crate::ast::*;
 use crate::lang::*;
 use crate::callable::core::*;
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimitiveList;
 
 impl PrimitiveSYM for PrimitiveList {

--- a/src/callable/primitive/q.rs
+++ b/src/callable/primitive/q.rs
@@ -4,7 +4,7 @@ use crate::ast::*;
 use crate::lang::*;
 use crate::callable::core::*;
 
-#[derive(Debug, Clone, Primitive)]
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PrimitiveQ;
 
 impl PrimitiveSYM for PrimitiveQ {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use crate::{parser::*, lang::CallStack};
 use core::fmt;
 use pest::error::LineColLocation::Pos;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RError {
     VariableNotFound(String),
     IncorrectContext(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate pest_derive;
+mod utils;
 
 pub mod ast;
 pub mod error;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,60 +1,16 @@
-use std::rc::Rc;
-
-// TODO: move eval to builtin accepting R::Expr to remove ast dependence, using just lang
-use crate::ast::{RExpr, RExprList};
-use crate::lang::*;
-use crate::r_builtins::builtins::Callable;
-use crate::r_vector::vectors::*;
-
-pub fn eval(expr: RExpr, env: &mut Environment) -> EvalResult {
-    use RVector::*;
-    use R::*;
-
-    match expr {
-        RExpr::Null => Ok(Null),
-        RExpr::NA => Ok(Vector(Logical(vec![OptionNA::NA]))),
-        RExpr::Inf => Ok(Vector(Numeric(vec![OptionNA::Some(f64::INFINITY)]))),
-        RExpr::Number(x) => Ok(Vector(RVector::from(vec![x]))),
-        RExpr::Integer(x) => Ok(Vector(RVector::from(vec![x]))),
-        RExpr::Bool(x) => Ok(Vector(Logical(vec![OptionNA::Some(x)]))),
-        RExpr::String(x) => Ok(Vector(Character(vec![OptionNA::Some(x)]))),
-        RExpr::Function(formals, body) => Ok(Function(formals, *body, Rc::clone(env))),
-        RExpr::Symbol(name) => env.get(name),
-        RExpr::List(x) => Ok(eval_rexprlist(x, &mut Rc::clone(env))?),
-        RExpr::Break => Err(RSignal::Condition(Cond::Break)),
-        RExpr::Continue => Err(RSignal::Condition(Cond::Continue)),
-        RExpr::Call(what, args) => match *what {
-            RExpr::Primitive(what) => Ok(what.call(args, env)?),
-            RExpr::String(what) | RExpr::Symbol(what) => Ok(what.call(args, env)?),
-            rexpr => (eval(rexpr, env)?).call(args, env),
-        },
-        x => unimplemented!("eval({})", x),
-    }
-}
-
-pub fn eval_rexprlist(x: RExprList, env: &mut Environment) -> EvalResult {
-    Ok(R::List(
-        x.into_iter()
-            .flat_map(|pair| match pair {
-                (_, RExpr::Ellipsis) => {
-                    if let Ok(R::List(ellipsis)) = env.get_ellipsis() {
-                        ellipsis.into_iter()
-                    } else {
-                        vec![].into_iter()
-                    }
-                }
-                (k, e @ (RExpr::Call(..) | RExpr::Symbol(..))) => {
-                    let elem = vec![(k, R::Closure(e, Rc::clone(env)))];
-                    elem.into_iter()
-                }
-                (k, v) => {
-                    if let Ok(elem) = eval(v, &mut Rc::clone(env)) {
-                        vec![(k, elem)].into_iter()
-                    } else {
-                        unreachable!()
-                    }
-                }
-            })
-            .collect(),
-    ))
+#[macro_export]
+macro_rules! assert_r_eq {
+    (R{ $($l:tt)+ }, R{ $($r:tt)+ }) => {{
+        let l = stringify!($($l)+);
+        let r = stringify!($($r)+);
+        assert_eq! (crate::repl::eval(l), crate::repl::eval(r));
+    }};
+    (R{ $($l:tt)+ }, $r:expr) => {{ {
+        let l = stringify!($($l)+);
+        assert_eq! (crate::repl::eval(l), $r);
+    } }};
+    ($l:expr, R{ $($r:tt)+ }) => {{ {
+        let r = stringify!($($r)+);
+        assert_eq! ($l, crate::repl::eval(r));
+    } }};
 }

--- a/src/vector/vectors.rs
+++ b/src/vector/vectors.rs
@@ -28,6 +28,7 @@ impl Vector {
     pub fn get(&self, index: usize) -> Option<Vector> {
         use Vector::*;
 
+        #[inline]
         fn f<T>(v: &Vec<T>, index: usize) -> Option<Vector>
         where
             T: Clone,


### PR DESCRIPTION
* Derives `PartialEq` for all lang and ast objects
* Had to do some nasty up-and-back-downcasting magic to implement `PartialEq` for `Primitive`s, thankfully covered in "Learning Rust" and was pretty easy to adapt.
* Added a `assert_r_eq!` macro that will parse and evaluate (most) R code and compare the output of the test case and expectation