### PR TITLE
Adding colon operator

### DIFF
--- a/src/callable/operators.rs
+++ b/src/callable/operators.rs
@@ -1,7 +1,8 @@
 use r_derive::Primitive;
 
 use crate::ast::*;
-use crate::lang::*;
+use crate::error::RError;
+use crate::lang::{CallStack, EvalResult, Context, R};
 use crate::vector::vectors::*;
 use super::core::*;
 
@@ -332,17 +333,63 @@ impl PrimitiveSYM for InfixColon {
 }
 
 impl Callable for InfixColon {
-    fn call(&self, args: ExprList, _stack: &mut CallStack) -> EvalResult {
-        // TODO: reduce call stack nesting here
-        let (lhs, rhs) = args.unnamed_binary_args();
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let mut argstream = args.into_iter();
+        let arg1 = argstream.next().map(|(_, v)| v).unwrap_or(Expr::Null);
+        let arg2 = argstream.next().map(|(_, v)| v).unwrap_or(Expr::Null);
 
-        use Expr::*;
-        match (lhs, rhs) {
-            (Number(l), Number(r)) => Ok(R::Vector(Vector::from(((l as i32)..=(r as i32)).into_iter().collect::<Vec<i32>>()))),
-            (Number(l), Integer(r)) => Ok(R::Vector(Vector::from(((l as i32)..=(r as i32)).into_iter().collect::<Vec<i32>>()))),
-            (Integer(l), Number(r)) => Ok(R::Vector(Vector::from(((l as i32)..=(r as i32)).into_iter().collect::<Vec<i32>>()))),
-            (Integer(l), Integer(r)) => Ok(R::Vector(Vector::from(((l as i32)..=(r as i32)).into_iter().collect::<Vec<i32>>()))),
-            _ => unreachable!(),
+        fn colon_args(arg: &Expr) -> Option<(Expr, Expr)> {
+            if let Expr::Call(what, largs) = arg.clone() {
+                if let Expr::Primitive(p) = *what {
+                    if p == (Box::new(InfixColon) as Box<dyn Primitive>) {
+                        return Some(largs.clone().unnamed_binary_args());
+                    }    
+                }
+            }
+
+            None
+        }
+
+        // handle special case of chained colon ops: `x:y:z`
+        if let Some((llhs, lrhs)) = colon_args(&arg1) {
+            // since we're rearranging calls here, we might need to modify the call stack
+            let args = ExprList::from(vec![(None, llhs), (None, lrhs), (None, arg2)]);
+            return InfixColon.call(args, stack);
+
+        // tertiary case
+        } else if let Some((_, arg3)) = argstream.next() {
+            // currently always returns numeric vector
+            let start: f64 = stack.eval(arg1)?.as_numeric()?.try_into()?;
+            let by: f64 = stack.eval(arg2)?.as_numeric()?.try_into()?;
+            let end: f64 = stack.eval(arg3)?.as_numeric()?.try_into()?;
+
+            if by == 0.0 {
+                return RError::Other("Cannot increment by 0".to_string()).into()
+            }
+
+            if (end - start) / by < 0.0 {
+                return Ok(R::Vector(Vector::Numeric(vec![])))
+            }
+
+            let mut v = start;
+            return Ok(R::Vector(Vector::from(
+                vec![start].into_iter()
+                    .chain(std::iter::repeat_with(|| { v += by; v }))
+                    .take_while(|x| if &start <= &end { x <= &end } else { x >= &end })
+                    .collect::<Vec<f64>>()
+            )))
+            
+        // binary case
+        } else {
+            let start: i32 = stack.eval(arg1)?.as_integer()?.try_into()?;
+            let end: i32 = stack.eval(arg2)?.as_integer()?.try_into()?;
+            return Ok(R::Vector(Vector::from(
+                if start <= end {
+                    (start..=end).into_iter().collect::<Vec<i32>>()
+                } else {
+                    (end..=start).into_iter().rev().collect::<Vec<i32>>()
+                }
+            )))
         }
     }
 }

--- a/src/callable/operators.rs
+++ b/src/callable/operators.rs
@@ -325,6 +325,29 @@ impl Callable for InfixPipe {
 }
 
 #[derive(Debug, Clone, Primitive, PartialEq)]
+pub struct InfixColon;
+
+impl PrimitiveSYM for InfixColon {
+    const SYM: &'static str = ":";
+}
+
+impl Callable for InfixColon {
+    fn call(&self, args: ExprList, _stack: &mut CallStack) -> EvalResult {
+        // TODO: reduce call stack nesting here
+        let (lhs, rhs) = args.unnamed_binary_args();
+
+        use Expr::*;
+        match (lhs, rhs) {
+            (Number(l), Number(r)) => Ok(R::Vector(Vector::from(((l as i32)..=(r as i32)).into_iter().collect::<Vec<i32>>()))),
+            (Number(l), Integer(r)) => Ok(R::Vector(Vector::from(((l as i32)..=(r as i32)).into_iter().collect::<Vec<i32>>()))),
+            (Integer(l), Number(r)) => Ok(R::Vector(Vector::from(((l as i32)..=(r as i32)).into_iter().collect::<Vec<i32>>()))),
+            (Integer(l), Integer(r)) => Ok(R::Vector(Vector::from(((l as i32)..=(r as i32)).into_iter().collect::<Vec<i32>>()))),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Primitive, PartialEq)]
 pub struct PostfixIndex;
 
 impl Format for PostfixIndex {

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -24,7 +24,7 @@
 //
 
     hl = _{ CAPTURE_WS? ~ ( hl_kws  ~ CAPTURE_WS? )* ~ eoi }
-        hl_kws = _{ hl_infix | hl_reserved | hl_control | hl_value | hl_call | hl_sym | hl_str | hl_ops | hl_brackets | hl_num | hl_other }
+        hl_kws = _{ hl_infix | hl_reserved | hl_control | hl_value | hl_call | hl_num | hl_sym | hl_str | hl_ops | hl_brackets | hl_other }
         hl_control = { "if" | "else" | "for" | "while" | "repeat" | "return" }
         hl_reserved = { "function" | "fn" }
         hl_value = { val_null | val_na | val_inf | val_true | val_false }
@@ -152,11 +152,9 @@
 
 // atomic value types
 
-    number = @{
-        "-"?
-        ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
-        ~ ("." ~ ASCII_DIGIT*)?
-    }
+    number = @{ "-"? ~ number_leading | number_trailing }
+        number_leading = { ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT*)? }
+        number_trailing = { "." ~ ASCII_DIGIT+ }
 
     integer_expr = _{ integer ~ "L" }
         integer = @{ "-"? ~ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -37,7 +37,7 @@
         hl_infix = { infix }
         hl_open = { "(" }
         hl_brackets = { hl_open | ")" | "[" | "]" | "{" | "}" }
-        hl_ops = { "," | "+" | "-" | "*" | "/" | "<" | ">" | "=" | "&" | "!" | "^" | "?" }
+        hl_ops = { "," | "+" | "-" | "*" | "/" | "<" | ">" | "=" | "&" | "!" | "^" | ":" | "::" | ":::" | "?" }
         hl_other = { ANY }
 
 
@@ -58,6 +58,7 @@
                 assign | 
                 add | subtract | multiply | divide | modulo | power | 
                 pipe | 
+                colon | doublecolon | triplecolon |
                 gte | lte | gt | eq | neq | lt | 
                 or | vor | and | vand | 
                 special
@@ -89,6 +90,9 @@
             // special
             special = { "%" ~ !("%") ~ "%" }
             pipe = { "|>" }
+            colon = { ":" }
+            doublecolon = { "::" }
+            triplecolon = { ":::" }
 
         prefix = _{ subtract | negate }
             negate = { "!" }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -32,8 +32,8 @@ lazy_static::lazy_static! {
             .op(Op::infix(add, Left) | Op::infix(subtract, Left))
             .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
             .op(Op::infix(modulo, Left) | Op::infix(special, Left) | Op::infix(pipe, Left))
-            .op(Op::infix(colon, Left))
             .op(Op::infix(power, Left))
+            .op(Op::infix(colon, Left))
    };
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -32,6 +32,7 @@ lazy_static::lazy_static! {
             .op(Op::infix(add, Left) | Op::infix(subtract, Left))
             .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
             .op(Op::infix(modulo, Left) | Op::infix(special, Left) | Op::infix(pipe, Left))
+            .op(Op::infix(colon, Left))
             .op(Op::infix(power, Left))
    };
 }
@@ -63,6 +64,7 @@ fn parse_expr(pairs: Pairs<Rule>) -> Expr {
                 Rule::multiply => Box::new(InfixMul),
                 Rule::divide => Box::new(InfixDiv),
                 Rule::power => Box::new(InfixPow),
+                Rule::colon => Box::new(InfixColon),
                 Rule::modulo => Box::new(InfixMod),
                 Rule::assign => Box::new(InfixAssign),
                 Rule::or => Box::new(InfixOr),


### PR DESCRIPTION
As a bonus, I added a tertiary colon operator as well (`1:2:10`).

Also fixed a longstanding bug with numeric parsing where `.3` would get interpreted as a variable name and not a number.