### PR TITLE
Mutable vector access, "alt-reps" and subestting

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -70,8 +70,9 @@
     }
 
     pre {
-      margin: 0.15rem;
+      margin: 0.3rem 0.1rem;
       white-space: pre-wrap;
+      line-height: 1.4em;
     }
 
     .container {
@@ -115,7 +116,7 @@
       overflow-y: scroll;
       scrollbar-width: none;
       scroll-behavior: smooth;
-      -webkit-mask-image: -webkit-linear-gradient(bottom, rgba(0,0,0,1) max(10em, 30vh), rgba(0,0,0,0.2) max(20em, 60vh));
+      -webkit-mask-image: -webkit-linear-gradient(bottom, rgba(0,0,0,1) max(15em, 35vh), rgba(0,0,0,0.2) max(25em, 60vh));
     }
 
     .history-scroll::-webkit-scrollbar {
@@ -131,10 +132,6 @@
       padding: 0.25em 0.5em;
       border-radius: 0.5em;
       margin: 0.25em 0;
-    }
-
-    .input > pre:before {
-      content: "> ";
     }
 
     .input, .output {
@@ -241,7 +238,7 @@
     #prompt {
       box-sizing: border-box;
       font-family: monospace, mono;
-      line-height: 1.5em;
+      line-height: 1.4em;
       width: 100%;
       resize: vertical;
 
@@ -348,7 +345,12 @@
         let parent = elem || document.getElementById("history");
         let node = document.createElement("div");
         let text = document.createElement("pre");
+
         node.className = "history-cell " + type;
+        if (type == "input") {
+          node.onclick = () => prompt_set(content);
+        }
+
         text.textContent = content;
         node.appendChild(text);
         parent.appendChild(node);

--- a/src/callable/primitive/c.rs
+++ b/src/callable/primitive/c.rs
@@ -17,91 +17,102 @@ impl Callable for PrimitiveC {
             unreachable!()
         };
 
-        // until there's a better way of handling type hierarchy, this will do
-        let t: u8 = vals
+        // lets first see what we're aiming to build.
+        let ty: u8 = vals
             .iter()
             .map(|(_, v)| match v {
                 R::Null => 0,
-                R::Vector(vec) => match vec {
-                    Vector::Logical(_) => 1,
-                    Vector::Integer(_) => 2,
-                    Vector::Numeric(_) => 3,
-                    Vector::Character(_) => 4,
-                },
-                R::List(_) => 5,
+                R::Vector(_) => 1,
+                R::List(_) => 2,
                 _ => 0,
             })
             .fold(0, std::cmp::max);
 
-        match t {
-            0 => Ok(R::Null),
-            // Coerce everything into logical
-            1 => {
-                let mut output = vec![OptionNA::Some(true); 0];
-                for (_, val) in vals {
-                    match val {
-                        R::Null => continue,
-                        R::Vector(Vector::Logical(mut v)) => output.append(&mut v),
-                        _ => unimplemented!(),
-                    }
-                }
-                Ok(R::Vector(Vector::Logical(output)))
-            }
-            // Coerce everything into integer
-            2 => {
-                let mut output = vec![OptionNA::Some(0); 0];
-                for (_, val) in vals {
-                    match val {
-                        R::Null => continue,
-                        R::Vector(Vector::Integer(mut v)) => output.append(&mut v),
-                        R::Vector(Vector::Logical(v)) => {
-                            output.append(&mut Vector::vec_coerce::<bool, i32>(&v))
-                        }
-                        _ => unimplemented!(),
-                    }
-                }
-                Ok(R::Vector(Vector::Integer(output)))
-            }
-            // Coerce everything into numeric
-            3 => {
-                let mut output = vec![OptionNA::Some(0.0); 0];
-                for (_, val) in vals {
-                    match val {
-                        R::Null => continue,
-                        R::Vector(Vector::Numeric(mut v)) => output.append(&mut v),
-                        R::Vector(Vector::Integer(v)) => {
-                            output.append(&mut Vector::vec_coerce::<i32, f64>(&v))
-                        }
-                        R::Vector(Vector::Logical(v)) => {
-                            output.append(&mut Vector::vec_coerce::<bool, f64>(&v))
-                        }
-                        _ => unimplemented!("{:#?}", val)
-                    }
-                }
-                Ok(R::Vector(Vector::Numeric(output)))
-            }
-            // coerce everything into strings
-            4 => {
-                let mut output = vec![OptionNA::Some("".to_string()); 0];
-                for (_, val) in vals {
-                    match val {
-                        R::Null => continue,
-                        R::Vector(Vector::Numeric(v)) => {
-                            output.append(&mut Vector::vec_coerce::<f64, String>(&v))
-                        }
-                        R::Vector(Vector::Integer(v)) => {
-                            output.append(&mut Vector::vec_coerce::<i32, String>(&v))
-                        }
-                        R::Vector(Vector::Logical(v)) => {
-                            output.append(&mut Vector::vec_coerce::<bool, String>(&v))
-                        }
-                        R::Vector(Vector::Character(mut v)) => output.append(&mut v),
-                        _ => unimplemented!("{:#?}", val)
-                    }
-                }
-                Ok(R::Vector(Vector::Character(output)))
-            }
-            _ => Ok(R::Null),
+        // most complex type was NULL
+        if ty == 0 { 
+            return Ok(R::Null)
         }
+
+        // most complex type was List
+        if ty == 2 { 
+            return Ok(R::List(vals))
+        }
+
+        // otherwise, try to collapse vectors into same type
+        let ret = vals.iter()
+            .map(|(_, r)| match r {
+                R::Vector(Vector::Logical(_)) => Vector::from(Vec::<Logical>::new()),
+                R::Vector(Vector::Integer(_)) => Vector::from(Vec::<Integer>::new()),
+                R::Vector(Vector::Numeric(_)) => Vector::from(Vec::<Numeric>::new()),
+                R::Vector(Vector::Character(_)) => Vector::from(Vec::<Character>::new()),
+                _ => unreachable!()
+            })
+            .fold(Vector::from(Vec::<Logical>::new()), |l, r| match (l, r) {
+                (v @ Vector::Character(_), _) => v,
+                (_, v @ Vector::Character(_)) => v,
+                (v @ Vector::Numeric(_), _) => v,
+                (_, v @ Vector::Numeric(_)) => v,
+                (v @ Vector::Integer(_), _) => v,
+                (_, v @ Vector::Integer(_)) => v,
+                (v @ Vector::Logical(_), _) => v,
+            });
+
+        // consume values and merge into a new collection
+        match ret {
+            Vector::Character(v) => {
+                Ok(R::Vector(Vector::from(
+                    v.inner().clone().borrow_mut().clone().into_iter()
+                        .chain(vals.into_iter().flat_map(|(_, i)| match i.as_character() {
+                            Ok(R::Vector(Vector::Character(v))) => {
+                                v.inner().clone().borrow().clone().into_iter()
+                            },
+                            _ => unreachable!()
+                        }))
+                        .map(|i| i.clone())
+                        .collect::<Vec<Character>>()
+                )))
+            },
+            Vector::Numeric(v) => {
+                Ok(R::Vector(Vector::from(
+                    v.inner().clone().borrow_mut().clone().into_iter()
+                        .chain(vals.into_iter().flat_map(|(_, i)| match i.as_numeric() {
+                            Ok(R::Vector(Vector::Numeric(v))) => {
+                                v.inner().clone().borrow().clone().into_iter()
+                            },
+                            _ => unreachable!()
+                        }))
+                        .map(|i| i.clone())
+                        .collect::<Vec<Numeric>>()
+                )))
+            },
+            Vector::Integer(v) => {
+                Ok(R::Vector(Vector::from(
+                    v.inner().clone().borrow_mut().clone().into_iter()
+                        .chain(vals.into_iter().flat_map(|(_, i)| match i.as_integer() {
+                            Ok(R::Vector(Vector::Integer(v))) => {
+                                v.inner().clone().borrow().clone().into_iter()
+                            },
+                            _ => unreachable!()
+                        }))
+                        .map(|i| i.clone())
+                        .collect::<Vec<Integer>>()
+                )))
+            },
+            Vector::Logical(v) => {
+                Ok(R::Vector(Vector::from(
+                    v.inner().clone().borrow_mut().clone().into_iter()
+                        .chain(vals.into_iter().flat_map(|(_, i)| match i.as_logical() {
+                            Ok(R::Vector(Vector::Logical(v))) => {
+                                v.inner().clone().borrow().clone().into_iter()
+                            },
+                            _ => unreachable!()
+                        }))
+                        .map(|i| i.clone())
+                        .collect::<Vec<Logical>>()
+                )))
+            },
+        }
+        
+
     }
 }

--- a/src/callable/primitive/paste.rs
+++ b/src/callable/primitive/paste.rs
@@ -113,7 +113,7 @@ mod test {
     fn only_null() {
         assert_eq!(
             r!{ paste(null) }, 
-            Ok(R::Vector(Vector::Character(vec![])))
+            Ok(R::Vector(Vector::from(Vec::<Character>::new())))
         );
     }
 

--- a/src/callable/primitive/paste.rs
+++ b/src/callable/primitive/paste.rs
@@ -3,7 +3,6 @@ use r_derive::*;
 use crate::ast::*;
 use crate::error::*;
 use crate::lang::*;
-use crate::vector::vectors::*;
 use crate::callable::core::*;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -35,8 +34,8 @@ impl Callable for PrimitivePaste {
                 continue
             };
             match (k.as_str(), v) {
-                ("sep", R::Vector(Vector::Character(v))) => {
-                    sep = v.get(0).unwrap().clone().to_string();
+                ("sep", R::Vector(v)) => {
+                    sep = v.into();
                 }
                 ("sep", _) => {
                     return Err(RSignal::Error(RError::Other(
@@ -44,9 +43,9 @@ impl Callable for PrimitivePaste {
                     )));
                 }
                 ("collapse", R::Null) => continue,
-                ("collapse", R::Vector(Vector::Character(v))) => {
+                ("collapse", R::Vector(v)) => {
                     should_collapse = true;
-                    collapse = v.get(0).unwrap().clone().to_string();
+                    collapse = v.into();
                 }
                 ("collapse", _) => {
                     return Err(RSignal::Error(RError::WithCallStack(
@@ -100,6 +99,7 @@ impl Callable for PrimitivePaste {
 mod test {
     use super::*;
     use crate::r;
+    use crate::vector::vectors::{Vector, Character};
 
     #[test]
     fn numeric_input() {

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -150,6 +150,21 @@ impl R {
         }
     }
 
+    pub fn assign(self, value: R) -> EvalResult {
+        // TODO(ERROR) cleanup
+        let err = RError::Other("Invalid target for assignment".to_string());
+        let err_list = RError::Other("Assignment to lists isn't yet implemented".to_string());
+
+        match self {
+            R::Vector(mut v) => {
+                v.assign(value.as_vector()?)?;
+                Ok(R::Vector(v.clone()))
+            },
+            R::List(_) => Err(err_list.into()),
+            _ => Err(err.into()),
+        }
+    }
+
     pub fn as_integer(self) -> EvalResult {
         match self {
             R::Vector(v) => Ok(R::Vector(v.as_integer())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate pest_derive;
-mod utils;
+
+pub mod utils;
 
 pub mod ast;
 pub mod error;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,15 @@
+pub trait SameType<T>: Sized {
+    fn is_same_type_as(&self, _other: &T) -> bool {
+        false
+    }
+}
+
+impl<T, U> SameType<T> for U {
+    fn is_same_type_as(&self, _other: &T) -> bool {
+        true
+    }
+}
+
 #[macro_export]
 macro_rules! r {
     // evaluate a single token directly

--- a/src/vector/coercion.rs
+++ b/src/vector/coercion.rs
@@ -214,7 +214,7 @@ where
     // bools, could be removed is specialized
     fn coerce_into(self) -> OptionNA<T> {
         match self {
-            OptionNA::Some(s) => s.to_lowercase().parse().map_or(OptionNA::NA, |i| OptionNA::Some(i)),
+            OptionNA::Some(s) => s.parse().map_or(OptionNA::NA, |i| OptionNA::Some(i)),
             OptionNA::NA => OptionNA::NA,
         }
     }    

--- a/src/vector/coercion.rs
+++ b/src/vector/coercion.rs
@@ -21,16 +21,6 @@ pub trait CoercibleInto<T>: Sized {
     fn coerce_into(self) -> T;
 }
 
-impl<T, U> CoercibleInto<U> for &T 
-where
-    T: CoercibleInto<U>
-{
-    #[allow(unconditional_recursion)]
-    fn coerce_into(self) -> U {
-        self.coerce_into()        
-    }
-}
-
 impl CoercibleInto<bool> for bool {
     #[inline]
     fn coerce_into(self) -> bool {

--- a/src/vector/iterators.rs
+++ b/src/vector/iterators.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use crate::vector::coercion::*;
 
 /// Zip iterators into recycling vectors, extending to longest length
@@ -13,20 +14,22 @@ use crate::vector::coercion::*;
 /// let z: Vec<_> = zip_recycle(x, y).collect();
 /// ````
 ///
-pub fn zip_recycle<'a, L, R, LIter, LItem, RIter, RItem>(
+pub fn zip_recycle<'a, L, R, LItem, RItem>(
     l: L,
     r: R,
 ) -> impl Iterator<Item = (LItem, RItem)> + 'a
 where
-    L: IntoIterator<Item = LItem, IntoIter = LIter> + 'a,
-    R: IntoIterator<Item = RItem, IntoIter = RIter> + 'a,
-    LIter: ExactSizeIterator + Iterator<Item = LItem> + Clone + 'a,
-    RIter: ExactSizeIterator + Iterator<Item = RItem> + Clone + 'a,
+    L: ExactSizeIterator + Iterator<Item = LItem> + Clone + 'a,
+    R: ExactSizeIterator + Iterator<Item = RItem> + Clone + 'a,
+    LItem: Clone + 'a,
+    RItem: Clone + 'a,
+    // LIter: ExactSizeIterator + Iterator<Item = LItem> + Clone + 'a,
+    // RIter: ExactSizeIterator + Iterator<Item = RItem> + Clone + 'a,
 {
-    let l_iter = l.into_iter();
-    let r_iter = r.into_iter();
-    let n = std::cmp::max(l_iter.len(), r_iter.len());
-    l_iter.cycle().zip(r_iter.cycle()).take(n)
+    let l = l.into_iter();
+    let r = r.into_iter();
+    let n = std::cmp::max(l.len(), r.len());
+    l.cycle().zip(r.cycle()).take(n)
 }
 
 /// Map an iterator of pairs into a pair of common numeric types
@@ -39,21 +42,23 @@ where
 ///
 /// * `i` - An iterator over pairs of numeric (or numeric-coercible) values
 ///
-pub fn map_common_numeric<I, LItem, RItem, LNum, RNum, Output>(
+pub fn map_common_numeric<I, LItem, RItem, DLItem, DRItem, LNum, RNum, Output>(
     i: I,
 ) -> impl Iterator<Item = (Output, Output)>
 where
     // iterator over pairs of items
     I: IntoIterator<Item = (LItem, RItem)>,
     // and item should be coercible to numeric
-    LItem: MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
-    RItem: MinimallyNumeric<As = RNum> + CoercibleInto<RNum>,
+    LItem: MinimallyNumeric<As = LNum> + Deref<Target = DLItem>,
+    RItem: MinimallyNumeric<As = RNum> + Deref<Target = DRItem>,
+    DLItem: CoercibleInto<LNum> + Clone,
+    DRItem: CoercibleInto<RNum> + Clone,
     // and those numerics should be coercible to a common numeric
     (LNum, RNum): CommonNum<Common = Output>,
 {
     i.into_iter()
         .map(|(l, r)| (
-            CoercibleInto::<LNum>::coerce_into(l),
-            CoercibleInto::<RNum>::coerce_into(r)
+            CoercibleInto::<LNum>::coerce_into(l.clone()),
+            CoercibleInto::<RNum>::coerce_into(r.clone())
         ).as_common())
 }

--- a/src/vector/iterators.rs
+++ b/src/vector/iterators.rs
@@ -39,48 +39,21 @@ where
 ///
 /// * `i` - An iterator over pairs of numeric (or numeric-coercible) values
 ///
-pub fn map_common_add_numeric<'a, I, LItem, RItem, LNum, RNum, Output>(
+pub fn map_common_numeric<I, LItem, RItem, LNum, RNum, Output>(
     i: I,
-) -> impl Iterator<Item = (Output, Output)> + 'a
+) -> impl Iterator<Item = (Output, Output)>
 where
     // iterator over pairs of items
-    I: IntoIterator<Item = (LItem, RItem)> + 'a,
+    I: IntoIterator<Item = (LItem, RItem)>,
     // and item should be coercible to numeric
-    LItem: IntoNumeric<LNum> + 'a,
-    LNum: 'a,
-    RItem: IntoNumeric<RNum> + 'a,
-    RNum: 'a,
+    LItem: MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
+    RItem: MinimallyNumeric<As = RNum> + CoercibleInto<RNum>,
     // and those numerics should be coercible to a common numeric
-    (LNum, RNum): CommonNum<Output> + 'a,
+    (LNum, RNum): CommonNum<Common = Output>,
 {
     i.into_iter()
-        .map(|(l, r)| (LItem::as_numeric(l), RItem::as_numeric(r)).as_common())
-}
-
-/// Map an iterator of pairs into a pair of common numeric types
-///
-/// Accept an iterator of pairs of numeric (or numeric-coercible) values and
-/// returns an iterator of pairs of numerics coerced to the least greater common
-/// type, assuming a hierarchy of representations.
-///
-/// # Arguments
-///
-/// * `i` - An iterator over pairs of numeric (or numeric-coercible) values
-///
-pub fn map_common_mul_numeric<'a, I, LItem, RItem, LNum, RNum, Output>(
-    i: I,
-) -> impl Iterator<Item = (Output, Output)> + 'a
-where
-    // iterator over pairs of items
-    I: IntoIterator<Item = (LItem, RItem)> + 'a,
-    // and item should be coercible to numeric
-    LItem: IntoNumeric<LNum> + 'a,
-    LNum: 'a,
-    RItem: IntoNumeric<RNum> + 'a,
-    RNum: 'a,
-    // and those numerics should be coercible to a common numeric
-    (LNum, RNum): CommonNum<Output> + 'a,
-{
-    i.into_iter()
-        .map(|(l, r)| (LItem::as_numeric(l), RItem::as_numeric(r)).as_common())
+        .map(|(l, r)| (
+            CoercibleInto::<LNum>::coerce_into(l),
+            CoercibleInto::<RNum>::coerce_into(r)
+        ).as_common())
 }

--- a/src/vector/iterators.rs
+++ b/src/vector/iterators.rs
@@ -11,20 +11,16 @@ use crate::vector::coercion::*;
 ///
 /// let x = vec![1, 2, 3, 4];
 /// let y = vec![2, 4];
-/// let z: Vec<_> = zip_recycle(x, y).collect();
+/// let z: Vec<_> = zip_recycle(x.into_iter(), y.into_iter()).collect();
 /// ````
 ///
-pub fn zip_recycle<'a, L, R, LItem, RItem>(
+pub fn zip_recycle<L, R, LItem, RItem>(
     l: L,
     r: R,
-) -> impl Iterator<Item = (LItem, RItem)> + 'a
+) -> impl Iterator<Item = (LItem, RItem)>
 where
-    L: ExactSizeIterator + Iterator<Item = LItem> + Clone + 'a,
-    R: ExactSizeIterator + Iterator<Item = RItem> + Clone + 'a,
-    LItem: Clone + 'a,
-    RItem: Clone + 'a,
-    // LIter: ExactSizeIterator + Iterator<Item = LItem> + Clone + 'a,
-    // RIter: ExactSizeIterator + Iterator<Item = RItem> + Clone + 'a,
+    L: ExactSizeIterator + Iterator<Item = LItem> + Clone,
+    R: ExactSizeIterator + Iterator<Item = RItem> + Clone,
 {
     let l = l.into_iter();
     let r = r.into_iter();

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -7,3 +7,6 @@
 pub mod coercion;
 pub mod iterators;
 pub mod vectors;
+pub mod rep;
+pub mod subsets;
+pub mod subset;

--- a/src/vector/rep.rs
+++ b/src/vector/rep.rs
@@ -1,0 +1,834 @@
+use crate::vector::vectors::{Numeric, Integer, Logical, Character};
+use std::cell::RefCell;
+use std::fmt::{Debug, Display};
+use std::rc::Rc;
+
+use super::coercion::{CoercibleInto, CommonCmp, MinimallyNumeric, CommonNum, AtomicMode};
+use super::iterators::{zip_recycle, map_common_numeric};
+use super::subset::Subset;
+use super::subsets::Subsets;
+use super::vectors::{OptionNA, Pow, VecPartialCmp};
+
+/// Vector
+#[derive(Debug, Clone, PartialEq)]
+pub enum Rep<T> {
+    // Vector::Subset encompasses a "raw" vector (no subsetting)
+    Subset(Rc<RefCell<Vec<T>>>, Subsets),
+
+    // Iterator includes things like ranges 1:Inf, and lazily computed values
+    // Iter(Box<dyn Iterator<Item = &T>>)
+}
+
+impl<T: AtomicMode + Clone + Default> Rep<T> {
+    /// Create an empty vector
+    ///
+    /// The primary use case for this function is to support testing, and there
+    /// are few expected use cases outside. It is used for creating a vector
+    /// of an explicit atomic type, likely to be tested with 
+    /// `SameType::is_same_type_as`.
+    ///
+    /// ```
+    /// use vec::vector::Vector;
+    /// use vec::types::OptionNa;
+    /// use vec::utils::SameType;
+    ///
+    /// let result = Vector::from(vec![1, 2, 3]);
+    /// let expect = Vector::<OptionNa<i32>>::new();
+    /// assert!(result.is_same_type_as(&expect));
+    /// ```
+    /// 
+    pub fn new() -> Self {
+        Rep::Subset(Rc::new(RefCell::new(Vec::new())), Subsets(Vec::new()))
+    }
+
+    /// Access the internal vector
+    pub fn inner(&self) -> Rc<RefCell<Vec<T>>> {
+        match self.materialize() {
+            Rep::Subset(v, _) => v.clone()
+        }
+    }
+
+    /// Subsetting a Vector
+    ///
+    /// Introduce a new subset into the aggregate list of subset indices.
+    ///
+    pub fn subset(&self, subset: Subset) -> Self {
+        match self {
+            Rep::Subset(v, Subsets(subsets)) => {
+                let mut subsets = subsets.clone();
+                subsets.push(subset.into());
+                Rep::Subset(v.clone(), Subsets(subsets))
+            },
+        }          
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Rep::Subset(v, Subsets(s)) => match s.as_slice() {
+                [] => v.clone().borrow().len(),
+                [.., last] => last.len()
+            },
+        }        
+    }
+
+    /// Get a single element from a vector
+    ///
+    /// Access a single element without materializing a new vector
+    ///
+    pub fn get(&self, index: usize) -> Option<Rep<T>> 
+    where
+        T: Clone
+    {
+        match self {
+            Rep::Subset(v, subsets) => {
+                let vc = v.clone();
+                let vb = vc.borrow();
+                let index = subsets.get_index_at(index)?;
+                let elem = vb.get(index)?;
+                Some(Rep::Subset(Rc::new(RefCell::new(vec![elem.clone()])), Subsets::new()))
+            },
+        }
+    }
+
+    /// Assignment to Subset Indices
+    ///
+    /// Assignment to a vector from another. The aggregate subsetted indices
+    /// are iterated over while performing the assignment.
+    ///
+    pub fn assign(&mut self, value: Self) 
+    where
+        T: Clone + Default
+    {
+        match (self, value) {
+            (Rep::Subset(lv, ls), Rep::Subset(rv, rs)) => {
+                let lvc = lv.clone(); let mut lv = lvc.borrow_mut();
+                let rvc = rv.clone(); let rv = rvc.borrow();
+
+                let lv_len = lv.len().clone();
+                let l_indices = ls.clone().into_iter()
+                    .take_while(|i| {
+                        match i {
+                            Some(i) => i < &lv_len,
+                            None => true,
+                        } 
+                    });
+
+                let r_indices = rs.clone().into_iter()
+                    .take_while(|i| {
+                        match i {
+                            Some(i) => i < &lv_len,
+                            None => true,
+                        } 
+                    });
+
+                for (li, ri) in l_indices.zip(r_indices) {
+                    match (li, ri) {
+                        (Some(li), None) => lv[li.saturating_sub(1)] = T::default(),
+                        (Some(li), Some(ri)) => lv[li.saturating_sub(1)] = rv[ri].clone(),
+                        _ => (),
+                    }
+                }
+            },
+        }
+    }
+
+    /// Materialize a Vector
+    ///
+    /// Apply subsets and clone values into a new vector.
+    ///
+    pub fn materialize(&self) -> Self 
+    where
+        T: Clone
+    {
+        match self {
+            Rep::Subset(v, subsets) => {      
+                let vc = v.clone();
+                let vb = vc.borrow();
+                let mut res: Vec<T> = vec![];
+                let vb_len = vb.len();
+
+                let iter = subsets.clone().into_iter()
+                    .take_while(|i| match i {
+                        Some(i) => i < &vb_len,
+                        None => true,
+                    });
+
+                for i in iter {
+                    match i {
+                        Some(i) => res.push(vb[i].clone()),
+                        None => res.push(T::default()),
+                    }
+                }
+
+                Rep::Subset(Rc::new(RefCell::new(res)), Subsets(vec![]))
+            },
+        }
+    }
+
+    /// Test the mode of the internal vector type
+    ///
+    /// Internally, this is defined by the [crate::types::atomic::AtomicMode] 
+    /// implementation of the vector's element type.
+    ///
+    /// ```
+    /// use vec::vector::Vector;
+    /// let v = Vector::from(vec![0_f32, 100_f32]);
+    /// assert!(v.is_numeric())
+    /// ```
+    ///
+    pub fn is_numeric(&self) -> bool {
+        T::is_numeric()
+    }
+
+    /// See [Self::is_numeric] for more information
+    pub fn is_logical(&self) -> bool {
+        T::is_logical()
+    }
+
+    /// See [Self::is_numeric] for more information
+    pub fn is_integer(&self) -> bool {
+        T::is_integer()
+    }
+
+    /// See [Self::is_numeric] for more information
+    pub fn is_character(&self) -> bool {
+        T::is_character()
+    }
+
+    /// Convert a Vector into a vector of a specific class of internal type
+    ///
+    /// The internal type only needs to satisfy [CoerceInto] for the `Mode`,
+    /// and for the `Mode` type to implement [Atomic]. Generally, this
+    /// is used more directly via [Self::as_logical], [Self::as_integer],
+    /// [Self::as_numeric] and [Self::as_character], which predefine the output
+    /// type of the mode.
+    ///
+    /// ```
+    /// use vec::vector::Vector;
+    ///
+    /// let x = Vector::from(vec![false, true, true, false]);
+    /// let n = x.as_numeric();
+    ///
+    /// assert_eq!(n, Vector::from(vec![0_f64, 1_f64, 1_f64, 0_f64]))
+    /// ```
+    ///
+    pub fn as_mode<Mode>(&self) -> Rep<Mode> 
+    where
+        T: CoercibleInto<Mode>,
+    {
+        match self {
+            Rep::Subset(v, subsets) => {
+                let vc = v.clone();
+                let vb = vc.borrow();
+
+                let num_vec: Vec<Mode> = vb.iter()
+                    .map(|i| (*i).clone().coerce_into())
+                    .collect();
+
+                Rep::Subset(Rc::new(RefCell::new(num_vec)), subsets.clone())
+            },
+        }
+    }
+
+    /// See [Self::as_mode] for more information
+    pub fn as_logical(&self) -> Rep<Logical> where T: CoercibleInto<Logical> {
+        self.as_mode::<Logical>()
+    }
+
+    /// See [Self::as_mode] for more information
+    pub fn as_integer(&self) -> Rep<Integer> where T: CoercibleInto<Integer> {
+        self.as_mode::<Integer>()
+    }
+
+    /// See [Self::as_mode] for more information
+    pub fn as_numeric(&self) -> Rep<Numeric> where T: CoercibleInto<Numeric> {
+        self.as_mode::<Numeric>()
+    }
+
+    /// See [Self::as_mode] for more information
+    pub fn as_character(&self) -> Rep<Character> where T: CoercibleInto<Character> {
+        self.as_mode::<Character>()
+    }
+
+    /// Apply over the vector contents to produce a vector of [std::cmp::Ordering]
+    ///
+    /// This function is used primarily in support of the implementation of
+    /// vectorized comparison operators and likely does not need to be used
+    /// outside of that context. 
+    ///
+    /// See [crate::vecops::VecPartialCmp] for vectorized comparison operator
+    /// implementations.
+    ///
+    pub fn vectorized_partial_cmp<R, C>(self, other: Rep<R>) -> Vec<Option<std::cmp::Ordering>>
+    where
+        T: AtomicMode + Default + Clone + CoercibleInto<C>,
+        R: AtomicMode + Default + Clone + CoercibleInto<C>,
+        (T, R): CommonCmp<Common = C>,
+        C: PartialOrd,
+    {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = other.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        zip_recycle(lhs, rhs)
+            .map(|(l, r)| {
+                let lc = CoercibleInto::<C>::coerce_into(l.clone());
+                let rc = CoercibleInto::<C>::coerce_into(r.clone());
+                lc.partial_cmp(&rc)
+            })
+            .collect()
+    }
+
+    fn get_inner(&self, index: usize) -> Option<T> {
+        match self {
+            Rep::Subset(v, subsets) => {
+                let vc = v.clone();
+                let vb = vc.borrow();
+                let index = subsets.get_index_at(index)?;
+                match vb.get(index) {
+                    Some(x) => Some(x.clone()),
+                    None => None,
+                }
+            },
+        }
+    }
+}
+
+impl<T> TryInto<bool> for Rep<OptionNA<T>> 
+where
+    OptionNA<T>: AtomicMode + Clone + CoercibleInto<OptionNA<bool>>
+{
+    type Error = ();
+    fn try_into(self) -> Result<bool, Self::Error> {
+        self.get_inner(0)
+            .map_or(Err(()), |i| match CoercibleInto::<OptionNA<bool>>::coerce_into(i) {
+                OptionNA::Some(x) => Ok(x),
+                OptionNA::NA => Err(()),
+            })
+    }
+}
+
+impl From<Vec<OptionNA<f64>>> for Rep<Numeric> {
+    fn from(value: Vec<OptionNA<f64>>) -> Self {
+        let value: Vec<_> = value.into_iter().map(|i| i.coerce_into()).collect();
+        Rep::Subset(Rc::new(RefCell::new(value)), Subsets(Vec::new()))
+    }
+}
+
+impl From<Vec<f64>> for Rep<Numeric> {
+    fn from(value: Vec<f64>) -> Self {
+        let value: Vec<_> = value.into_iter().map(|i| i.coerce_into()).collect();
+        Rep::Subset(Rc::new(RefCell::new(value)), Subsets(Vec::new()))
+    }
+}
+
+impl From<Vec<OptionNA<i32>>> for Rep<Integer> {
+    fn from(value: Vec<OptionNA<i32>>) -> Self {
+        let value: Vec<_> = value.into_iter().map(|i| i.coerce_into()).collect();
+        Rep::Subset(Rc::new(RefCell::new(value)), Subsets(Vec::new()))
+    }
+}
+
+impl From<Vec<i32>> for Rep<Integer> {
+    fn from(value: Vec<i32>) -> Self {
+        let value: Vec<_> = value.into_iter().map(|i| i.coerce_into()).collect();
+        Rep::Subset(Rc::new(RefCell::new(value)), Subsets(Vec::new()))
+    }
+}
+
+impl From<Vec<OptionNA<bool>>> for Rep<Logical> {
+    fn from(value: Vec<OptionNA<bool>>) -> Self {
+        let value: Vec<_> = value.into_iter().map(|i| i.coerce_into()).collect();
+        Rep::Subset(Rc::new(RefCell::new(value)), Subsets(Vec::new()))
+    }
+}
+
+impl From<Vec<bool>> for Rep<Logical> {
+    fn from(value: Vec<bool>) -> Self {
+        let value: Vec<_> = value.into_iter().map(|i| i.coerce_into()).collect();
+        Rep::Subset(Rc::new(RefCell::new(value)), Subsets(Vec::new()))
+    }
+}
+
+impl From<Vec<OptionNA<String>>> for Rep<Character> {
+    fn from(value: Vec<OptionNA<String>>) -> Self {
+        let value: Vec<_> = value.into_iter().map(|i| i.coerce_into()).collect();
+        Rep::Subset(Rc::new(RefCell::new(value)), Subsets(Vec::new()))
+    }
+}
+
+impl From<Vec<String>> for Rep<Character> {
+    fn from(value: Vec<String>) -> Self {
+        let value: Vec<_> = value.into_iter().map(|i| i.coerce_into()).collect();
+        Rep::Subset(Rc::new(RefCell::new(value)), Subsets(Vec::new()))
+    }
+}
+
+
+impl<F, T> From<(Vec<F>, Subsets)> for Rep<T> 
+where
+    Rep<T>: From<Vec<F>>
+{
+    fn from(value: (Vec<F>, Subsets)) -> Self {
+        match Self::from(value.0) {
+            Rep::Subset(v, _) => Rep::Subset(v, value.1),
+        }
+    }
+}
+
+impl<T> Display for Rep<T> 
+where
+    T: AtomicMode + Display + Default + Clone
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let n = self.len();
+        if n == 0 {
+            return write!(f, "[]")
+        }
+
+        let nlen = format!("{}", n).len();
+        // TODO: iteratively calculate when we hit max print so our
+        // max_len isn't inflated by a value that is omitted
+
+        let xc = self.inner().clone();
+        let xb = xc.borrow();
+
+        let x_strs = xb.iter().map(|xi| format!("{}", xi));
+        let max_len = x_strs
+            .clone()
+            .fold(0, |max_len, xi| std::cmp::max(max_len, xi.len()));
+
+        let mut col = 0;
+        let gutterlen = 2 + nlen + 1;
+
+        // hard coded max print & console width
+        let maxprint = 20 * ((80 - gutterlen) / max_len);
+
+        x_strs.take(maxprint).enumerate().try_for_each(|(i, x_str)| {
+            if i == 0 {
+                col = gutterlen + max_len;
+                write!(f, "{:>3$}[{}] {:>4$}", "", i + 1, x_str, nlen - 1, max_len)
+            } else if col + 1 + max_len > 80 {
+                col = gutterlen + max_len;
+                let i_str = format!("{}", i + 1);
+                let gutter = nlen - i_str.len();
+                write!(f, "\n{:>3$}[{}] {:>4$}", "", i_str, x_str, gutter, max_len)
+            } else {
+                col += 1 + max_len;
+                write!(f, " {:>1$}", x_str, max_len)
+            }
+        })?;
+
+        if n > maxprint {
+            write!(f, "\n[ omitting {} entries ]", n - maxprint)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<L, LNum, O> std::ops::Neg for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
+    LNum: std::ops::Neg<Output = O>,
+    Rep<O>: From<Vec<O>>,
+{
+    type Output = Rep<O>;
+    fn neg(self) -> Self::Output {
+        Rep::from(
+            self.inner().clone().borrow().iter()
+                .map(|l| CoercibleInto::<LNum>::coerce_into(l).neg())
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, C, O, LNum, RNum> std::ops::Add<Rep<R>> for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
+    R: AtomicMode + Default + Clone + MinimallyNumeric<As = RNum> + CoercibleInto<RNum>,
+    (LNum, RNum): CommonNum<Common = C>,
+    C: Clone + std::ops::Add<Output = O>,
+    Rep<C>: From<Vec<O>>,
+{
+    type Output = Rep<C>;
+    fn add(self, rhs: Rep<R>) -> Self::Output {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = rhs.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        Rep::from(
+            map_common_numeric(zip_recycle(lhs, rhs))
+                .map(|(l, r)| l + r)
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, C, O, LNum, RNum> std::ops::Sub<Rep<R>> for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
+    R: AtomicMode + Default + Clone + MinimallyNumeric<As = RNum> + CoercibleInto<RNum>,
+    (LNum, RNum): CommonNum<Common = C>,
+    C: std::ops::Sub<Output = O>,
+    Rep<C>: From<Vec<O>>,
+{
+    type Output = Rep<C>;
+    fn sub(self, rhs: Rep<R>) -> Self::Output {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = rhs.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        Rep::from(
+            map_common_numeric(zip_recycle(lhs, rhs))
+                .map(|(l, r)| l - r)
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, C, O, LNum, RNum> std::ops::Mul<Rep<R>> for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
+    R: AtomicMode + Default + Clone + MinimallyNumeric<As = RNum> + CoercibleInto<RNum>,
+    (LNum, RNum): CommonNum<Common = C>,
+    C: std::ops::Mul<Output = O>,
+    Rep<C>: From<Vec<O>>,
+{
+    type Output = Rep<C>;
+    fn mul(self, rhs: Rep<R>) -> Self::Output {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = rhs.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        Rep::from(
+            map_common_numeric(zip_recycle(lhs, rhs))
+                .map(|(l, r)| l * r)
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, C, O, LNum, RNum> std::ops::Div<Rep<R>> for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
+    R: AtomicMode + Default + Clone + MinimallyNumeric<As = RNum> + CoercibleInto<RNum>,
+    (LNum, RNum): CommonNum<Common = C>,
+    C: std::ops::Div<Output = O>,
+    Rep<C>: From<Vec<O>>,
+{
+    type Output = Rep<C>;
+    fn div(self, rhs: Rep<R>) -> Self::Output {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = rhs.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        Rep::from(
+            map_common_numeric(zip_recycle(lhs, rhs))
+                .map(|(l, r)| l / r)
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, C, O, LNum, RNum> std::ops::Rem<Rep<R>> for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
+    R: AtomicMode + Default + Clone + MinimallyNumeric<As = RNum> + CoercibleInto<RNum>,
+    (LNum, RNum): CommonNum<Common = C>,
+    C: std::ops::Rem<Output = O>,
+    Rep<C>: From<Vec<O>>,
+{
+    type Output = Rep<C>;
+    fn rem(self, rhs: Rep<R>) -> Self::Output {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = rhs.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        Rep::from(
+            map_common_numeric(zip_recycle(lhs, rhs))
+                .map(|(l, r)| l.rem(r))
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, O, LNum, RNum> Pow<Rep<R>> for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + MinimallyNumeric<As = LNum> + CoercibleInto<LNum>,
+    R: AtomicMode + Default + Clone + MinimallyNumeric<As = RNum> + CoercibleInto<RNum>,
+    LNum: Pow<RNum, Output = O>,
+    Rep<O>: From<Vec<O>>,
+{
+    type Output = Rep<O>;
+    fn power(self, rhs: Rep<R>) -> Self::Output {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = rhs.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        Rep::from(
+            zip_recycle(lhs, rhs)
+                .map(|(l, r)| CoercibleInto::<LNum>::coerce_into(l).power(CoercibleInto::<RNum>::coerce_into(r)))
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, O> std::ops::BitOr<Rep<R>> for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + CoercibleInto<Logical>,
+    R: AtomicMode + Default + Clone + CoercibleInto<Logical>,
+    Logical: std::ops::BitOr<Logical, Output = O>,
+    Rep<O>: From<Vec<O>>,
+{
+    type Output = Rep<O>;
+    fn bitor(self, rhs: Rep<R>) -> Self::Output {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = rhs.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        Rep::from(
+            zip_recycle(lhs, rhs)
+                .map(|(l, r)| CoercibleInto::<Logical>::coerce_into(l).bitor(CoercibleInto::<Logical>::coerce_into(r)))
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, O> std::ops::BitAnd<Rep<R>> for Rep<L> 
+where
+    L: AtomicMode + Default + Clone + CoercibleInto<Logical>,
+    R: AtomicMode + Default + Clone + CoercibleInto<Logical>,
+    Logical: std::ops::BitAnd<Logical, Output = O>,
+    Rep<O>: From<Vec<O>>,
+{
+    type Output = Rep<O>;
+    fn bitand(self, rhs: Rep<R>) -> Self::Output {
+        let lc = self.inner().clone();
+        let lb = lc.borrow();
+        let lhs = lb.iter();
+
+        let rc = rhs.inner().clone();
+        let rb = rc.borrow();
+        let rhs = rb.iter();
+
+        Rep::from(
+            zip_recycle(lhs, rhs)
+                .map(|(l, r)| CoercibleInto::<Logical>::coerce_into(l).bitand(CoercibleInto::<Logical>::coerce_into(r)))
+                .collect::<Vec<O>>()
+        )
+    }
+}
+
+impl<L, R, C> VecPartialCmp<Rep<R>> for Rep<L>
+where
+    L: AtomicMode + Default + Clone + CoercibleInto<C>,
+    R: AtomicMode + Default + Clone + CoercibleInto<C>,
+    (L, R): CommonCmp<Common = C>,
+    C: PartialOrd,
+{
+    type Output = Rep<Logical>;
+
+    fn vec_gt(self, rhs: Rep<R>) -> Self::Output {
+        use std::cmp::Ordering::*;
+        self.vectorized_partial_cmp(rhs)
+            .into_iter()
+            .map(|i| match i {
+                Some(Greater) => OptionNA::Some(true),
+                Some(_) => OptionNA::Some(false),
+                None => OptionNA::NA,
+            })
+            .collect::<Vec<Logical>>()
+            .into()
+    }
+
+    fn vec_gte(self, rhs: Rep<R>) -> Self::Output {
+        use std::cmp::Ordering::*;
+        self.vectorized_partial_cmp(rhs)
+            .into_iter()
+            .map(|i| match i {
+                Some(Greater | Equal) => OptionNA::Some(true),
+                Some(_) => OptionNA::Some(false),
+                None => OptionNA::NA,
+            })
+            .collect::<Vec<Logical>>()
+            .into()
+    }
+
+    fn vec_lt(self, rhs: Rep<R>) -> Self::Output {
+        use std::cmp::Ordering::*;
+        self.vectorized_partial_cmp(rhs)
+            .into_iter()
+            .map(|i| match i {
+                Some(Less) => OptionNA::Some(true),
+                Some(_) => OptionNA::Some(false),
+                None => OptionNA::NA,
+            })
+            .collect::<Vec<Logical>>()
+            .into()
+    }
+
+    fn vec_lte(self, rhs: Rep<R>) -> Self::Output {
+        use std::cmp::Ordering::*;
+        self.vectorized_partial_cmp(rhs)
+            .into_iter()
+            .map(|i| match i {
+                Some(Less | Equal) => OptionNA::Some(true),
+                Some(_) => OptionNA::Some(false),
+                None => OptionNA::NA,
+            })
+            .collect::<Vec<Logical>>()
+            .into()
+    }
+
+    fn vec_eq(self, rhs: Rep<R>) -> Self::Output {
+        use std::cmp::Ordering::*;
+        self.vectorized_partial_cmp(rhs)
+            .into_iter()
+            .map(|i| match i {
+                Some(Equal) => OptionNA::Some(true),
+                Some(_) => OptionNA::Some(false),
+                None => OptionNA::NA,
+            })
+            .collect::<Vec<Logical>>()
+            .into()
+    }
+
+    fn vec_neq(self, rhs: Rep<R>) -> Self::Output {
+        use std::cmp::Ordering::*;
+        self.vectorized_partial_cmp(rhs)
+            .into_iter()
+            .map(|i| match i {
+                Some(Equal) => OptionNA::Some(false),
+                Some(_) => OptionNA::Some(true),
+                None => OptionNA::NA,
+            })
+            .collect::<Vec<Logical>>()
+            .into()
+    }
+}
+
+
+// #[cfg(test)]
+// mod test{
+//     use super::*;
+
+//     #[test]
+//     fn vector_add() {
+//         let x = Rep::from((1..=10).into_iter().collect::<Vec<_>>());
+//         let y = Rep::from(vec![2, 5, 6, 2, 3]);
+
+//         let z = x + y;
+//         assert_eq!(z, Rep::from(vec![3, 7, 9, 6, 8, 8, 12, 14, 11, 13]));
+
+//         let expected_type = Rep::<OptionNa<i32>>::new();
+//         assert!(z.is_same_type_as(&expected_type));
+//         assert!(z.is_integer());
+//     }
+
+//     #[test]
+//     fn vector_mul() {
+//         let x = Rep::from((1..=10).into_iter().collect::<Vec<_>>());
+//         let y = Rep::from(vec![
+//             OptionNa(Some(2)), OptionNa(None), OptionNa(Some(6)), 
+//             OptionNa(None), OptionNa(Some(3))
+//         ]);
+
+//         let z = x * y;
+//         assert_eq!(z, Rep::from(vec![
+//             OptionNa(Some(2)), OptionNa(None), OptionNa(Some(18)), 
+//             OptionNa(None), OptionNa(Some(15)), OptionNa(Some(12)), 
+//             OptionNa(None), OptionNa(Some(48)), OptionNa(None), 
+//             OptionNa(Some(30))
+//         ]));
+
+//         let expected_type = Rep::<OptionNa<i32>>::new();
+//         assert!(z.is_same_type_as(&expected_type));
+//         assert!(z.is_integer());
+//     }
+
+//     #[test]
+//     fn vector_common_mul_f32_na() {
+//         // expect that f32's do not get coerced into an OptionNa, instead
+//         // using std::f32::NAN as NA representation.
+
+//         let x = Rep::from(vec![0_f32, std::f32::NAN, 10_f32]);
+//         let y = Rep::from(vec![100, 10]);
+
+//         let z = x * y;
+//         // assert_eq!(z, Vector::from(vec![0_f32, std::f32::NAN, 1_000_f32]));
+//         // comparing floats is error prone
+
+//         let expected_type = Rep::<f32>::new();
+//         assert!(z.is_same_type_as(&expected_type));
+//         assert!(z.is_numeric());
+//     }
+
+//     #[test]
+//     fn vector_and() {
+//         // expect that f32's do not get coerced into an OptionNa, instead
+//         // using std::f32::NAN as NA representation.
+
+//         let x = Rep::from(vec![0_f32, std::f32::NAN, 10_f32]);
+//         let y = Rep::from(vec![100, 10]);
+
+//         let z = x & y;
+//         assert_eq!(z, Rep::from(vec![OptionNa(Some(false)), OptionNa(None), OptionNa(Some(true))]));
+
+//         let expected_type = Rep::<OptionNa<bool>>::new();
+//         assert!(z.is_same_type_as(&expected_type));
+//         assert!(z.is_logical());
+//     }
+
+//     #[test]
+//     fn vector_gt() {
+//         // expect that f32's do not get coerced into an OptionNa, instead
+//         // using std::f32::NAN as NA representation.
+
+//         let x = Rep::from(vec![0_f32, std::f32::NAN, 10000_f32]);
+//         let y = Rep::from(vec![100, 10]);
+
+//         let z = x.vec_gt(y);
+//         assert_eq!(z, Rep::from(vec![
+//             OptionNa(Some(false)), 
+//             OptionNa(None), 
+//             OptionNa(Some(true))
+//         ]));
+
+//         let expected_type = Rep::<OptionNa<bool>>::new();
+//         assert!(z.is_same_type_as(&expected_type));
+//         assert!(z.is_logical());
+//     }
+// }

--- a/src/vector/subset.rs
+++ b/src/vector/subset.rs
@@ -1,0 +1,72 @@
+use std::{ops::Range, cell::RefCell, rc::Rc};
+
+use crate::lang::RSignal;
+
+use super::vectors::{Vector, Integer, OptionNA};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Subset {
+    Indices(Rc<RefCell<Vec<Integer>>>),
+    Range(Range<usize>)
+}
+
+impl Subset {
+    pub fn get_index_at(&self, index: usize) -> Option<usize> {
+        match self {
+            Subset::Indices(indices) => indices.clone().borrow()
+                .get(index)
+                .and_then(|i| match i {
+                    OptionNA::Some(i) => Some((*i as usize).saturating_sub(1)),
+                    OptionNA::NA => None,
+                }),
+            Subset::Range(range) => {
+                if range.start <= index && index < range.end {
+                    return Some(range.start + index)
+                } else {
+                    return None
+                }
+            },
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Subset::Indices(i) => i.clone().borrow().len(),
+            Subset::Range(r) => r.end - r.start,
+        }
+    }
+}
+
+impl From<usize> for Subset {
+    fn from(value: usize) -> Self {
+        Subset::Indices(Rc::new(RefCell::new(
+            vec![OptionNA::Some(value as i32)]
+        )))
+    }
+}
+
+impl From<Range<usize>> for Subset {
+    fn from(value: Range<usize>) -> Self {
+        Subset::Range(value)
+    }
+}
+
+impl From<Vec<usize>> for Subset {
+    fn from(value: Vec<usize>) -> Self {
+        Subset::Indices(Rc::new(RefCell::new(
+            value.iter()
+                .map(|i| OptionNA::Some(*i as i32))
+                .collect::<Vec<_>>()
+        )))
+    }
+}
+
+impl TryFrom<Vector> for Subset {
+    type Error = RSignal;
+    fn try_from(value: Vector) -> Result<Self, Self::Error> {
+        match value.as_integer() {
+            Vector::Integer(v) => Ok(Subset::Indices(v.materialize().inner().clone())),
+            _ => unreachable!()
+        }
+    }
+}

--- a/src/vector/subsets.rs
+++ b/src/vector/subsets.rs
@@ -1,0 +1,259 @@
+use super::{subset::Subset, vectors::OptionNA};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Subsets(pub Vec<Subset>);
+
+impl Subsets {
+    pub fn new() -> Self {
+        Subsets(Vec::new())
+    }
+
+    /// Get the raw index of a index applied to a subset
+    ///
+    /// Provided a vector with multiple subsets applied, determine which 
+    /// original index corresponds with the index applied to the subset.
+    ///
+    pub fn get_index_at(&self, mut index: usize) -> Option<usize> {
+        let Subsets(subsets) = self;
+        for subset in subsets.into_iter().rev() {
+            match subset.get_index_at(index) {
+                Some(i) => index = i,
+                None => return None,              
+            }
+        }
+        Some(index)
+    }
+
+    pub fn push<T>(self, subset: T) 
+    where
+        T: Into<Subset>
+    {
+        let Subsets(mut v) = self;
+        v.push(subset.into());
+    }
+}
+
+impl<T> From<Vec<T>> for Subsets
+where
+    T: Into<Subset>
+{
+    fn from(value: Vec<T>) -> Self {
+        let v: Vec<Subset> = value.into_iter().map(|i| i.into()).collect();
+        Subsets(v)
+    }
+}
+
+impl IntoIterator for Subsets {
+    type Item = Option<usize>;
+    type IntoIter = Box<dyn Iterator<Item = Self::Item>>;
+
+    /// Convert Subsets into an iterator if indices
+    ///
+    /// Builds an iterator of indices from a collection of subsets.
+    ///
+    /// # Examples
+    ///
+    /// /// let subsets = Subsets::new()
+    /// ///     .push(1..) 
+    /// ///     .push(vec![1, 9, 1, 7]);
+    /// ///
+    /// /// let indices: Vec<_> = subsets.into_iter().collect();
+    /// /// assert_eq!(indices, vec![2, 10, 2, 8])
+    ///
+    fn into_iter(self) -> Self::IntoIter {
+        let Subsets(subsets) = self;
+        let mut iter = Box::new((0_usize..).map(|i| Some(i)).into_iter()) as Self::IntoIter;
+        for subset in subsets {
+            let l = subset.len();
+            match subset {
+                Subset::Indices(i) => {
+                    // fastest case, when no indices are selected
+                    if l == 0 {
+                        return Box::new(vec![].into_iter());
+
+                    // very fast case, when one index is selected
+                    } else if l == 1 {
+                        let msg = "Expected at least one element to index by";
+                        if let OptionNA::Some(to_first) = i.clone().borrow().get(0).expect(msg) {
+                            iter = Box::new(iter.skip(*to_first as usize).take(1));
+                        } else {
+                            iter = Box::new(vec![None].into_iter())
+                        }
+
+                    // fast case, when indices are already sorted
+                    } else if i.clone().borrow().windows(2).all(|w| w[0] <= w[1]) {
+                        // when sorted, we can keep our existing iterator and
+                        // embed the indices, scanning along the iterator
+                        // and yielding indices as they are encountered
+                        let ic = i.clone();
+                        let ib = ic.borrow().clone();
+
+                        iter = Box::new(
+                            iter.enumerate().scan((ib, 0), |(indices, i), (xi, x)| -> Option<Vec<Option<usize>>> {
+                                if *i >= indices.len() { 
+                                    return None
+                                }
+
+                                let mut n = 0;
+                                while *i < indices.len() && indices[*i] == OptionNA::Some(xi as i32) {
+                                    n += 1;
+                                    *i += 1;
+                                };
+
+                                return Some(vec![x; n])
+                            })
+                            .flat_map(|i| i)
+                        )
+
+                    // worst case, indices in random order
+                    } else {
+                        // enumerate indices and swap so it's (index, enumeration)
+                        let ic = i.clone();
+                        let ib = ic.borrow();
+
+                        let mut order = ib.iter()
+                            .enumerate()
+                            .map(|(i, v)| (v, i.clone()))
+                            .collect::<Vec<_>>();
+
+                        // sort by index to get (sorted indices, order)
+                        // we'll use this to sample the existing iterator then 
+                        // permute it back into the original order
+                        order.sort();
+                        let (mut i, order): (Vec<_>, Vec<_>) = order.into_iter().unzip();
+
+                        // we'll populate this with the sorted indices first
+                        let mut indices: Vec<Option<usize>> = vec![None; i.len()];
+                        let n_na = i.iter().take_while(|&i| **i == OptionNA::NA).count();
+
+                        // populate non-na elements
+                        i.insert(n_na, &OptionNA::Some(0));
+                        let diffs = i[n_na..].windows(2)
+                            .map(|w| {
+                                if let OptionNA::Some(i) = w[1].clone() - w[0].clone() { 
+                                    i 
+                                } else { 
+                                    unreachable!()
+                                }
+                            });
+
+                        let mut last = iter.nth(0).expect("exhausted iterator"); for (i, diff) in diffs.enumerate() {
+                            if diff > 0 {
+                                last = iter.nth((diff - 1) as usize).expect("exhausted iterator");
+                            }
+                            indices[order[i + n_na]] = last;
+                        }
+
+                        // and finally we convert our new indices into an iterator
+                        iter = Box::new(indices.into_iter())
+                    }
+                },
+                Subset::Range(range) => {
+                    iter = Box::new(
+                        iter.skip(range.start)
+                            .enumerate()
+                            .take_while(move |(i, _)| i < &(range.end - range.start))
+                            .map(|(_, v)| v)
+                    ) as Self::IntoIter
+                },
+            }
+        }
+
+        iter
+    }
+}
+
+// #[cfg(test)]
+//  mod test {
+//     use crate::vector::Vector;
+
+//     #[test]
+//     fn subset_range() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(2..6).materialize();
+//         let expect = Vector::from(vec![3, 4, 5, 6]);
+//         assert_eq!(result, expect)
+//     }
+
+//     #[test]
+//     fn subset_sequential_indices() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(vec![2, 3, 4, 5]).materialize();
+//         let expect = Vector::from(vec![3, 4, 5, 6]);
+//         assert_eq!(result, expect)
+//     }
+
+//     #[test]
+//     fn subset_sequential_repeating_indices() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(vec![2, 3, 3, 3, 5, 5]).materialize();
+//         let expect = Vector::from(vec![3, 4, 4, 4, 6, 6]);
+//         assert_eq!(result, expect)
+//     }
+
+//     #[test]
+//     fn subset_indices_with_gap() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(vec![2, 8]).materialize();
+//         let expect = Vector::from(vec![3, 9]);
+//         assert_eq!(result, expect);
+//     }
+
+//     #[test]
+//     fn subset_empty_indices() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(vec![]).materialize();
+//         let expect = Vector::from(Vec::new() as Vec<i32>);
+//         assert_eq!(result, expect);
+//     }
+
+//     #[test]
+//     fn subset_single_index() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(vec![6]).materialize();
+//         let expect = Vector::from(vec![7]);
+//         assert_eq!(result, expect);
+//     }
+
+//     #[test]
+//     fn subset_unsorted_indices() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(vec![6, 2, 1, 4]).materialize();
+//         let expect = Vector::from(vec![7, 3, 2, 5]);
+//         assert_eq!(result, expect);
+//     }
+
+//     #[test]
+//     fn subset_repeated_indices() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(vec![6, 2, 6, 6]).materialize();
+//         let expect = Vector::from(vec![7, 3, 7, 7]);
+//         assert_eq!(result, expect);
+//     }
+
+//     #[test]
+//     fn subset_by_range() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(3..6).materialize();
+//         let expect = Vector::from(vec![4, 5, 6]);
+//         assert_eq!(result, expect);
+//     }
+
+//     #[test]
+//     fn nested_subsets() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let result = x.subset(3..6).subset(vec![2, 1]).materialize();
+//         let expect = Vector::from(vec![6, 5]);
+//         assert_eq!(result, expect);
+//     }
+
+//     #[test]
+//     fn subset_assignment() {
+//         let x: Vector<_> = (1..=10).into_iter().collect::<Vec<_>>().into();
+//         let subset = x.subset(3..6).subset(vec![2, 1]);
+//         let y: Vector<_> = vec![101, 102].into();
+//         subset.assign(y);
+//         let expect = Vector::from(vec![1, 2, 3, 4, 102, 101, 7, 8, 9, 10]);
+//         assert_eq!(x, expect)
+//     }
+// }

--- a/src/vector/vectors.rs
+++ b/src/vector/vectors.rs
@@ -2,24 +2,54 @@ use std::fmt::Debug;
 use std::fmt::Display;
 
 use crate::error::RError;
+use crate::lang::EvalResult;
+use crate::lang::R;
 use crate::lang::RSignal;
 use crate::vector::coercion::CoercibleInto;
 
-use super::coercion::*;
-use super::iterators::*;
+use super::coercion::AtomicMode;
+use super::rep::Rep;
+use super::subset::Subset;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub enum OptionNA<T> {
-    Some(T),
     NA,
+    Some(T),
 }
+
+impl<T> OptionNA<T> {
+    pub fn map<F, U>(self, f: F) -> OptionNA<U> 
+    where
+        F: FnOnce(T) -> U
+    {
+        match self {
+            OptionNA::Some(x) => OptionNA::Some(f(x)),
+            OptionNA::NA => OptionNA::NA,
+        }     
+    }
+}
+
+impl<T> Default for OptionNA<T> {
+    fn default() -> Self {
+        OptionNA::NA
+    }
+}
+
+pub type Numeric = OptionNA<f64>;
+impl AtomicMode for Numeric { fn is_numeric() -> bool { true }}
+pub type Integer = OptionNA<i32>;
+impl AtomicMode for Integer { fn is_integer() -> bool { true }}
+pub type Logical = OptionNA<bool>;
+impl AtomicMode for Logical { fn is_logical() -> bool { true }}
+pub type Character = OptionNA<String>;
+impl AtomicMode for Character { fn is_character() -> bool { true }}
 
 #[derive(Debug, Clone)]
 pub enum Vector {
-    Numeric(Vec<OptionNA<f64>>),
-    Integer(Vec<OptionNA<i32>>),
-    Logical(Vec<OptionNA<bool>>),
-    Character(Vec<OptionNA<String>>),
+    Numeric(Rep<Numeric>),
+    Integer(Rep<Integer>),
+    Logical(Rep<Logical>),
+    Character(Rep<Character>),
     // Complex(Complex),
     // Raw(Raw),
 }
@@ -27,69 +57,51 @@ pub enum Vector {
 impl Vector {
     pub fn get(&self, index: usize) -> Option<Vector> {
         use Vector::*;
-
-        #[inline]
-        fn f<T>(v: &Vec<T>, index: usize) -> Option<Vector>
-        where
-            T: Clone,
-            Vector: From<Vec<T>>,
-        {
-            if let Some(value) = v.get(index - 1) {
-                Some(Vector::from(vec![value.clone()]))
-            } else {
-                None
-            }
-        }
-
         match self {
-            Numeric(x) => f(x, index),
-            Integer(x) => f(x, index),
-            Logical(x) => f(x, index),
-            Character(x) => f(x, index),
+            Numeric(x) => x.get(index).map(|i| Numeric(i)),
+            Integer(x) => x.get(index).map(|i| Integer(i)),
+            Logical(x) => x.get(index).map(|i| Logical(i)),
+            Character(x) => x.get(index).map(|i| Character(i)),
         }
     }
 
-    pub fn set_from_vec(&mut self, index: Vector, values: Vector) -> Result<(), RSignal> {
-        let index = index.as_integer();
-
-        let i = match index.as_integer() {
-            Vector::Integer(ivec) => match ivec[..] {
-                [OptionNA::Some(i)] => i,
-                _ => {
-                    return Err(RSignal::Error(RError::Other(
-                        "can only index into vector with integer indices".to_string(),
-                    )))
-                }
+    pub fn try_get(&self, index: R) -> EvalResult {
+        let err = RError::Other("Vector index cannot be coerced into a valid indexing type.".to_string());
+        match (self, index.as_vector()?) {
+            (Vector::Numeric(v), R::Vector(i)) => {
+                Ok(R::Vector(Vector::from(v.subset(i.try_into()?))))
             },
-            _ => unreachable!(),
-        };
-
-        if values.len() != 1 {
-            return Err(RSignal::Error(RError::Other(
-                "cannot assign multiple values to single index".to_string(),
-            )));
-        };
-
-        use Vector::*;
-        match self {
-            Numeric(l) => match values.as_numeric() {
-                Numeric(r) => l[(i - 1) as usize] = r[0].clone(),
-                _ => unreachable!(),
+            (Vector::Integer(v), R::Vector(i)) => {
+                Ok(R::Vector(Vector::from(v.subset(i.try_into()?))))
             },
-            Integer(l) => match values.as_integer() {
-                Integer(r) => l[(i - 1) as usize] = r[0].clone(),
-                _ => unreachable!(),
+            (Vector::Logical(v), R::Vector(i)) => {
+                Ok(R::Vector(Vector::from(v.subset(i.try_into()?))))
             },
-            Logical(l) => match values.as_logical() {
-                Logical(r) => l[(i - 1) as usize] = r[0].clone(),
-                _ => unreachable!(),
+            (Vector::Character(v), R::Vector(i)) => {
+                Ok(R::Vector(Vector::from(v.subset(i.try_into()?))))
             },
-            Character(l) => match values.as_character() {
-                Character(r) => l[(i - 1) as usize] = r[0].clone(),
-                _ => unreachable!(),
-            },
+            _ => Err(err.into())
         }
+    }
 
+    pub fn subset(&self, subset: Subset) -> Self {
+        match self {
+            Vector::Numeric(x) => x.subset(subset.into()).into(),
+            Vector::Integer(x) => x.subset(subset.into()).into(),
+            Vector::Logical(x) => x.subset(subset.into()).into(),
+            Vector::Character(x) => x.subset(subset.into()).into(),
+        }
+    }
+
+    pub fn assign(&mut self, other: Self) -> Result<(), RSignal> {
+        let err = RError::Other("Cannot assign to a vector from a different type".to_string()).into();
+        match (self, other) {
+            (Vector::Numeric(l), Vector::Numeric(r)) => l.assign(r).into(),
+            (Vector::Integer(l), Vector::Integer(r)) => l.assign(r).into(),
+            (Vector::Logical(l), Vector::Logical(r)) => l.assign(r).into(),
+            (Vector::Character(l), Vector::Character(r)) => l.assign(r).into(),
+            _ => return Err(err)
+        }
         Ok(())
     }
 
@@ -132,13 +144,10 @@ impl Vector {
     pub fn as_integer(self) -> Vector {
         use Vector::*;
         match self {
-            Numeric(v) => Integer(Self::vec_coerce::<f64, i32>(&v)),
+            Numeric(v) => Integer(v.as_integer()),
             Integer(_) => self,
-            Logical(v) => Integer(Self::vec_coerce::<bool, i32>(&v)),
-            Character(v) => {
-                let (_any_new_nas, v) = Self::vec_parse::<i32>(&v);
-                Integer(v)
-            }
+            Logical(v) => Integer(v.as_integer()),
+            Character(v) => Integer(v.as_integer())
         }
     }
 
@@ -146,34 +155,28 @@ impl Vector {
         use Vector::*;
         match self {
             Numeric(_) => self,
-            Integer(v) => Numeric(Self::vec_coerce::<i32, f64>(&v)),
-            Logical(v) => Numeric(Self::vec_coerce::<bool, f64>(&v)),
-            Character(v) => {
-                let (_any_new_nas, v) = Self::vec_parse::<f64>(&v);
-                Numeric(v)
-            }
+            Integer(v) => Numeric(v.as_numeric()),
+            Logical(v) => Numeric(v.as_numeric()),
+            Character(v) => Numeric(v.as_numeric())
         }
     }
 
     pub fn as_logical(self) -> Vector {
         use Vector::*;
         match self {
-            Numeric(v) => Logical(v.into_iter().map(|i| i.as_logical()).collect::<Vec<_>>()),
-            Integer(v) => Logical(v.into_iter().map(|i| i.as_logical()).collect::<Vec<_>>()),
+            Numeric(v) => Logical(v.as_logical()),
+            Integer(v) => Logical(v.as_logical()),
             Logical(_) => self,
-            Character(v) => {
-                let (_any_new_nas, v) = Self::vec_parse::<bool>(&v);
-                Logical(v)
-            }
+            Character(v) => Logical(v.as_logical())
         }
     }
 
     pub fn as_character(self) -> Vector {
         use Vector::*;
         match self {
-            Numeric(v) => Character(Self::vec_coerce::<f64, String>(&v)),
-            Integer(v) => Character(Self::vec_coerce::<i32, String>(&v)),
-            Logical(v) => Character(Self::vec_coerce::<bool, String>(&v)),
+            Numeric(v) => Character(v.as_character()),
+            Integer(v) => Character(v.as_character()),
+            Logical(v) => Character(v.as_character()),
             Character(_) => self,
         }
     }
@@ -187,110 +190,97 @@ impl Vector {
             Character(v) => v.len(),
         }
     }
-
-    pub fn reserve(self, additional: usize) {
-        use Vector::*;
-        match self {
-            Numeric(mut v) => v.reserve(additional),
-            Integer(mut v) => v.reserve(additional),
-            Logical(mut v) => v.reserve(additional),
-            Character(mut v) => v.reserve(additional),
-        }
-    }
 }
 
 impl TryInto<bool> for Vector {
     type Error = ();
     fn try_into(self) -> Result<bool, Self::Error> {
-        use OptionNA::*;
         use Vector::*;
         match self {
-            Numeric(v) => match v[..] {
-                [Some(vi)] if vi == 0_f64 => Ok(false),
-                [Some(_)] => Ok(true),
-                [NA] => Err(()), // missing value where TRUE/FALSE needed
-                [] => Err(()),   // argument is of length zero
-                _ => Err(()),    // condition has length > 1
-            },
-            Integer(v) => match v[..] {
-                [Some(0)] => Ok(false),
-                [Some(_)] => Ok(true),
-                [NA] => Err(()), // missing value where TRUE/FALSE needed
-                [] => Err(()),   // argument is of length zero
-                _ => Err(()),    // condition has length > 1
-            },
-            Logical(v) => match v[..] {
-                [Some(true)] => Ok(true),
-                [Some(false)] => Ok(false),
-                [NA] => Err(()), // missing value where TRUE/FALSE needed
-                [] => Err(()),   // argument is of length zero
-                _ => Err(()),    // condition has length > 1
-            },
-            Character(v) => match &v[..] {
-                [Some(x)] if x.as_str() == "TRUE" => Ok(true),
-                [Some(x)] if x.as_str() == "FALSE" => Ok(false),
-                [Some(_)] => Err(()), // argument is not interpretable as logical
-                [NA] => Err(()),      // missing value where TRUE/FALSE needed
-                [] => Err(()),        // argument is of length zero
-                _ => Err(()),         // condition has length > 1
-            },
+            Numeric(i) => i.try_into(),
+            Integer(i) => i.try_into(),
+            Logical(i) => i.try_into(),
+            Character(i) => i.try_into(),
         }
+    }
+}
+
+impl From<Rep<Numeric>> for Vector {
+    fn from(x: Rep<Numeric>) -> Self {
+        Vector::Numeric(x)
+    }
+}
+
+impl From<Rep<Integer>> for Vector {
+    fn from(x: Rep<Integer>) -> Self {
+        Vector::Integer(x)
+    }
+}
+
+impl From<Rep<Logical>> for Vector {
+    fn from(x: Rep<Logical>) -> Self {
+        Vector::Logical(x)
+    }
+}
+
+impl From<Rep<Character>> for Vector {
+    fn from(x: Rep<Character>) -> Self {
+        Vector::Character(x)
     }
 }
 
 impl From<Vec<f64>> for Vector {
     fn from(x: Vec<f64>) -> Self {
-        Vector::Numeric(x.into_iter().map(|i| OptionNA::Some(i)).collect())
+        Vector::Numeric(x.into())
     }
 }
 
 impl From<Vec<OptionNA<f64>>> for Vector {
     fn from(x: Vec<OptionNA<f64>>) -> Self {
-        Vector::Numeric(x)
+        Vector::Numeric(x.into())
     }
 }
 
 impl From<Vec<i32>> for Vector {
     fn from(x: Vec<i32>) -> Self {
-        Vector::Integer(x.into_iter().map(|i| OptionNA::Some(i)).collect())
+        Vector::Integer(x.into())
     }
 }
 
 impl From<Vec<OptionNA<i32>>> for Vector {
     fn from(x: Vec<OptionNA<i32>>) -> Self {
-        Vector::Integer(x)
+        Vector::Integer(x.into())
     }
 }
 
 impl From<Vec<bool>> for Vector {
     fn from(x: Vec<bool>) -> Self {
-        Vector::Logical(x.into_iter().map(|i| OptionNA::Some(i)).collect())
+        Vector::Logical(x.into())
     }
 }
 
 impl From<bool> for Vector {
     fn from(x: bool) -> Self {
-        Self::from(vec![x])
+        Vector::Logical(vec![x].into())
     }
 }
 
 impl From<Vec<OptionNA<bool>>> for Vector {
     fn from(x: Vec<OptionNA<bool>>) -> Self {
-        Vector::Logical(x)
+        Vector::Logical(x.into())
     }
 }
 
 impl From<Vec<String>> for Vector {
     fn from(x: Vec<String>) -> Self {
-        Vector::Character(x.into_iter().map(|i| OptionNA::Some(i)).collect())
+        Vector::Character(x.into())
     }
 }
 
 impl Into<Vec<String>> for Vector {
     fn into(self) -> Vec<String> {
         match self.as_character() {
-            Vector::Character(v) => v
-                .iter()
+            Vector::Character(v) => v.inner().clone().borrow().iter()
                 .map(|x| match x {
                     OptionNA::Some(val) => val.clone(),
                     OptionNA::NA => "NA".to_string(),
@@ -303,7 +293,7 @@ impl Into<Vec<String>> for Vector {
 
 impl From<Vec<OptionNA<String>>> for Vector {
     fn from(x: Vec<OptionNA<String>>) -> Self {
-        Vector::Character(x)
+        Vector::Character(x.into())
     }
 }
 
@@ -333,78 +323,21 @@ where
 
 impl Display for Vector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fn fmt_vec<T>(x: &Vec<T>, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
-        where
-            T: Display,
-        {
-            let n = x.len();
-            let nlen = format!("{}", n).len();
-
-            // TODO: iteratively calculate when we hit max print so our
-            // max_len isn't inflated by a value that is omitted
-
-            let x_strs = x.iter().map(|xi| format!("{}", xi));
-            let max_len = x_strs
-                .clone()
-                .fold(0, |max_len, xi| std::cmp::max(max_len, xi.len()));
-
-            let mut col = 0;
-            let gutterlen = 2 + nlen + 1;
-
-            // hard coded max print & console width
-            let maxprint = 20 * ((80 - gutterlen) / max_len);
-
-            x_strs.take(maxprint).enumerate().try_for_each(|(i, x_str)| {
-                if i == 0 {
-                    col = gutterlen + max_len;
-                    write!(f, "{:>3$}[{}] {:>4$}", "", i + 1, x_str, nlen - 1, max_len)
-                } else if col + 1 + max_len > 80 {
-                    col = gutterlen + max_len;
-                    let i_str = format!("{}", i + 1);
-                    let gutter = nlen - i_str.len();
-                    write!(f, "\n{:>3$}[{}] {:>4$}", "", i_str, x_str, gutter, max_len)
-                } else {
-                    col += 1 + max_len;
-                    write!(f, " {:>1$}", x_str, max_len)
-                }
-            })?;
-
-            if n > maxprint {
-                write!(f, "\n[ omitting {} entries ]", n - maxprint)?;
-            }
-
-            Ok(())
-        }
-
-        fn fmt_strs(x: &Vec<OptionNA<String>>) -> Vec<String> {
-            use OptionNA::*;
-            x.into_iter()
-                .map(|i| match i {
-                    Some(x) => format!("\"{}\"", x),
-                    NA => "NA".to_string(),
-                })
-                .collect()
-        }
-
-        match (self.len(), self) {
-            (0, Vector::Numeric(_)) => write!(f, "numeric(0)"),
-            (0, Vector::Integer(_)) => write!(f, "integer(0)"),
-            (0, Vector::Logical(_)) => write!(f, "logical(0)"),
-            (0, Vector::Character(_)) => write!(f, "character(0)"),
-            (_, Vector::Numeric(x)) => fmt_vec(x, f),
-            (_, Vector::Integer(x)) => fmt_vec(x, f),
-            (_, Vector::Logical(x)) => fmt_vec(x, f),
-            (_, Vector::Character(x)) => fmt_vec(&fmt_strs(x), f),
+        match self {
+            Vector::Numeric(x) => std::fmt::Display::fmt(&x, f),
+            Vector::Integer(x) => std::fmt::Display::fmt(&x, f),
+            Vector::Logical(x) => std::fmt::Display::fmt(&x, f),
+            Vector::Character(x) => std::fmt::Display::fmt(&x, f),
         }
     }
 }
 
-impl<T> std::ops::Add for OptionNA<T>
+impl<T, U, O> std::ops::Add<OptionNA<U>> for OptionNA<T>
 where
-    T: std::ops::Add<Output = T>,
+    T: std::ops::Add<U, Output = O>,
 {
-    type Output = OptionNA<T>;
-    fn add(self, rhs: Self) -> Self::Output {
+    type Output = OptionNA<O>;
+    fn add(self, rhs: OptionNA<U>) -> Self::Output {
         use OptionNA::*;
         match (self, rhs) {
             (Some(l), Some(r)) => Some(l + r),
@@ -469,32 +402,42 @@ where
     }
 }
 
-pub trait Pow {
+pub trait Pow<Rhs> {
     type Output;
     /// raise self to the rhs power
-    fn power(self, rhs: Self) -> Self::Output;
+    fn power(self, rhs: Rhs) -> Self::Output;
 }
 
-impl Pow for i32 {
+impl Pow<i32> for i32 {
     type Output = i32;
     fn power(self, rhs: Self) -> Self::Output {
         i32::pow(self, rhs as u32)
     }
 }
 
-impl Pow for f64 {
+impl Pow<f64> for i32 {
     type Output = f64;
-    fn power(self, rhs: Self) -> Self::Output {
-        f64::powf(self, rhs)
+    fn power(self, rhs: f64) -> Self::Output {
+        f64::powf(self as f64, rhs)
     }
 }
 
-impl<T> Pow for OptionNA<T>
+impl<T> Pow<T> for f64 
 where
-    T: Pow,
+    f64: From<T>
 {
-    type Output = OptionNA<<T as Pow>::Output>;
-    fn power(self, rhs: Self) -> Self::Output {
+    type Output = f64;
+    fn power(self, rhs: T) -> Self::Output {
+        f64::powf(self, rhs.into())
+    }
+}
+
+impl<T, U, O> Pow<OptionNA<U>> for OptionNA<T>
+where
+    T: Pow<U, Output = O>,
+{
+    type Output = OptionNA<O>;
+    fn power(self, rhs: OptionNA<U>) -> Self::Output {
         use OptionNA::*;
         match (self, rhs) {
             (Some(l), Some(r)) => Some(T::power(l, r)),
@@ -517,36 +460,55 @@ where
     }
 }
 
+impl std::ops::BitOr<Logical> for Logical {
+    type Output = Logical;
+    fn bitor(self, rhs: Logical) -> Self::Output {
+        use OptionNA::*;
+        match (self, rhs) {
+            (Some(l), Some(r)) => Some(l || r),
+            _ => NA,
+        }
+    }
+}
+
+impl std::ops::BitAnd<Logical> for Logical {
+    type Output = Logical;
+    fn bitand(self, rhs: Logical) -> Self::Output {
+        use OptionNA::*;
+        match (self, rhs) {
+            (Some(l), Some(r)) => Some(l && r),
+            _ => NA,
+        }
+    }
+}
+
+impl std::ops::Neg for Vector {
+    type Output = Vector;
+    fn neg(self) -> Self::Output {
+        use Vector::*;
+        match self {
+            Numeric(x) => Numeric(x.neg()),
+            Integer(x) => Integer(x.neg()),
+            Logical(x) => Integer(x.neg()),
+            _ => todo!(),
+        }
+    }
+}
+
 impl std::ops::Add for Vector {
     type Output = Vector;
     fn add(self, rhs: Self) -> Self::Output {
         use Vector::*;
-
-        fn f<L, R, LNum, RNum, LRNum>(l: Vec<L>, r: Vec<R>) -> Vector
-        where
-            L: IntoNumeric<LNum> + Clone,
-            R: IntoNumeric<RNum> + Clone,
-            (LNum, RNum): CommonNum<LRNum>,
-            Vector: From<Vec<<LRNum as std::ops::Add>::Output>>,
-            LRNum: std::ops::Add,
-        {
-            Vector::from(
-                map_common_add_numeric(zip_recycle(l, r))
-                    .map(|(l, r)| l + r)
-                    .collect::<Vec<_>>(),
-            )
-        }
-
         match (self, rhs) {
-            (Numeric(l), Numeric(r)) => f(l, r),
-            (Numeric(l), Integer(r)) => f(l, r),
-            (Numeric(l), Logical(r)) => f(l, r),
-            (Integer(l), Numeric(r)) => f(l, r),
-            (Integer(l), Integer(r)) => f(l, r),
-            (Integer(l), Logical(r)) => f(l, r),
-            (Logical(l), Numeric(r)) => f(l, r),
-            (Logical(l), Integer(r)) => f(l, r),
-            (Logical(l), Logical(r)) => f(l, r),
+            (Numeric(l), Numeric(r)) => (l + r).into(),
+            (Numeric(l), Integer(r)) => (l + r).into(),
+            (Numeric(l), Logical(r)) => (l + r).into(),
+            (Integer(l), Numeric(r)) => (l + r).into(),
+            (Integer(l), Integer(r)) => (l + r).into(),
+            (Integer(l), Logical(r)) => (l + r).into(),
+            (Logical(l), Numeric(r)) => (l + r).into(),
+            (Logical(l), Integer(r)) => (l + r).into(),
+            (Logical(l), Logical(r)) => (l + r).into(),
             _ => todo!(),
         }
     }
@@ -556,59 +518,16 @@ impl std::ops::Sub for Vector {
     type Output = Vector;
     fn sub(self, rhs: Self) -> Self::Output {
         use Vector::*;
-
-        fn f<L, R, LNum, RNum, LRNum>(l: Vec<L>, r: Vec<R>) -> Vector
-        where
-            L: IntoNumeric<LNum> + Clone,
-            R: IntoNumeric<RNum> + Clone,
-            (LNum, RNum): CommonNum<LRNum>,
-            Vector: From<Vec<<LRNum as std::ops::Sub>::Output>>,
-            LRNum: std::ops::Sub,
-        {
-            Vector::from(
-                map_common_add_numeric(zip_recycle(l, r))
-                    .map(|(l, r)| l - r)
-                    .collect::<Vec<_>>(),
-            )
-        }
-
         match (self, rhs) {
-            (Numeric(l), Numeric(r)) => f(l, r),
-            (Numeric(l), Integer(r)) => f(l, r),
-            (Numeric(l), Logical(r)) => f(l, r),
-            (Integer(l), Numeric(r)) => f(l, r),
-            (Integer(l), Integer(r)) => f(l, r),
-            (Integer(l), Logical(r)) => f(l, r),
-            (Logical(l), Numeric(r)) => f(l, r),
-            (Logical(l), Integer(r)) => f(l, r),
-            (Logical(l), Logical(r)) => f(l, r),
-            _ => todo!(),
-        }
-    }
-}
-
-impl std::ops::Neg for Vector {
-    type Output = Vector;
-    fn neg(self) -> Self::Output {
-        use Vector::*;
-
-        fn f<T, TNum>(x: Vec<T>) -> Vector
-        where
-            T: IntoNumeric<TNum>,
-            Vector: From<Vec<<TNum as std::ops::Neg>::Output>>,
-            TNum: std::ops::Neg,
-        {
-            Vector::from(
-                x.into_iter()
-                    .map(|i| i.as_numeric().neg())
-                    .collect::<Vec<_>>(),
-            )
-        }
-
-        match self {
-            Numeric(x) => f(x),
-            Integer(x) => f(x),
-            Logical(x) => f(x),
+            (Numeric(l), Numeric(r)) => (l - r).into(),
+            (Numeric(l), Integer(r)) => (l - r).into(),
+            (Numeric(l), Logical(r)) => (l - r).into(),
+            (Integer(l), Numeric(r)) => (l - r).into(),
+            (Integer(l), Integer(r)) => (l - r).into(),
+            (Integer(l), Logical(r)) => (l - r).into(),
+            (Logical(l), Numeric(r)) => (l - r).into(),
+            (Logical(l), Integer(r)) => (l - r).into(),
+            (Logical(l), Logical(r)) => (l - r).into(),
             _ => todo!(),
         }
     }
@@ -618,32 +537,16 @@ impl std::ops::Mul for Vector {
     type Output = Vector;
     fn mul(self, rhs: Self) -> Self::Output {
         use Vector::*;
-
-        fn f<L, R, LNum, RNum, LRNum>(l: Vec<L>, r: Vec<R>) -> Vector
-        where
-            L: IntoNumeric<LNum> + Clone,
-            R: IntoNumeric<RNum> + Clone,
-            (LNum, RNum): CommonNum<LRNum>,
-            Vector: From<Vec<<LRNum as std::ops::Mul>::Output>>,
-            LRNum: std::ops::Mul,
-        {
-            Vector::from(
-                map_common_mul_numeric(zip_recycle(l, r))
-                    .map(|(l, r)| l * r)
-                    .collect::<Vec<_>>(),
-            )
-        }
-
         match (self, rhs) {
-            (Numeric(l), Numeric(r)) => f(l, r),
-            (Numeric(l), Integer(r)) => f(l, r),
-            (Numeric(l), Logical(r)) => f(l, r),
-            (Integer(l), Numeric(r)) => f(l, r),
-            (Integer(l), Integer(r)) => f(l, r),
-            (Integer(l), Logical(r)) => f(l, r),
-            (Logical(l), Numeric(r)) => f(l, r),
-            (Logical(l), Integer(r)) => f(l, r),
-            (Logical(l), Logical(r)) => f(l, r),
+            (Numeric(l), Numeric(r)) => (l * r).into(),
+            (Numeric(l), Integer(r)) => (l * r).into(),
+            (Numeric(l), Logical(r)) => (l * r).into(),
+            (Integer(l), Numeric(r)) => (l * r).into(),
+            (Integer(l), Integer(r)) => (l * r).into(),
+            (Integer(l), Logical(r)) => (l * r).into(),
+            (Logical(l), Numeric(r)) => (l * r).into(),
+            (Logical(l), Integer(r)) => (l * r).into(),
+            (Logical(l), Logical(r)) => (l * r).into(),
             _ => todo!(),
         }
     }
@@ -653,212 +556,182 @@ impl std::ops::Div for Vector {
     type Output = Vector;
     fn div(self, rhs: Self) -> Self::Output {
         use Vector::*;
-
-        fn f<L, R, LNum, RNum, LRNum>(l: Vec<L>, r: Vec<R>) -> Vector
-        where
-            L: IntoNumeric<LNum> + Clone,
-            R: IntoNumeric<RNum> + Clone,
-            (LNum, RNum): CommonNum<LRNum>,
-            Vector: From<Vec<<LRNum as std::ops::Div>::Output>>,
-            LRNum: std::ops::Div,
-        {
-            Vector::from(
-                map_common_mul_numeric(zip_recycle(l, r))
-                    .map(|(l, r)| l / r)
-                    .collect::<Vec<_>>(),
-            )
-        }
-
         match (self, rhs) {
-            (Numeric(l), Numeric(r)) => f(l, r),
-            (Numeric(l), Integer(r)) => f(l, r),
-            (Numeric(l), Logical(r)) => f(l, r),
-            (Integer(l), Numeric(r)) => f(l, r),
-            (Integer(l), Integer(r)) => f(l, r),
-            (Integer(l), Logical(r)) => f(l, r),
-            (Logical(l), Numeric(r)) => f(l, r),
-            (Logical(l), Integer(r)) => f(l, r),
-            (Logical(l), Logical(r)) => f(l, r),
+            (Numeric(l), Numeric(r)) => (l / r).into(),
+            (Numeric(l), Integer(r)) => (l / r).into(),
+            (Numeric(l), Logical(r)) => (l / r).into(),
+            (Integer(l), Numeric(r)) => (l / r).into(),
+            (Integer(l), Integer(r)) => (l / r).into(),
+            (Integer(l), Logical(r)) => (l / r).into(),
+            (Logical(l), Numeric(r)) => (l / r).into(),
+            (Logical(l), Integer(r)) => (l / r).into(),
+            (Logical(l), Logical(r)) => (l / r).into(),
             _ => todo!(),
         }
     }
 }
 
-impl Pow for Vector {
+impl Pow<Vector> for Vector {
     type Output = Vector;
     fn power(self, rhs: Self) -> Self::Output {
         use Vector::*;
-
-        fn f<L, R, LNum, RNum, LRNum>(l: Vec<L>, r: Vec<R>) -> Vector
-        where
-            L: IntoNumeric<LNum> + Clone,
-            R: IntoNumeric<RNum> + Clone,
-            (LNum, RNum): CommonNum<LRNum>,
-            Vector: From<Vec<<LRNum as Pow>::Output>>,
-            LRNum: Pow,
-        {
-            Vector::from(
-                map_common_mul_numeric(zip_recycle(l, r))
-                    .map(|(l, r)| LRNum::power(l, r))
-                    .collect::<Vec<_>>(),
-            )
-        }
-
         match (self, rhs) {
-            (Numeric(l), Numeric(r)) => f(l, r),
-            (Numeric(l), Integer(r)) => f(l, r),
-            (Numeric(l), Logical(r)) => f(l, r),
-            (Integer(l), Numeric(r)) => f(l, r),
-            (Integer(l), Integer(r)) => f(l, r),
-            (Integer(l), Logical(r)) => f(l, r),
-            (Logical(l), Numeric(r)) => f(l, r),
-            (Logical(l), Integer(r)) => f(l, r),
-            (Logical(l), Logical(r)) => f(l, r),
+            (Numeric(l), Numeric(r)) => l.power(r).into(),
+            (Numeric(l), Integer(r)) => l.power(r).into(),
+            (Numeric(l), Logical(r)) => l.power(r).into(),
+            (Integer(l), Numeric(r)) => l.power(r).into(),
+            (Integer(l), Integer(r)) => l.power(r).into(),
+            (Integer(l), Logical(r)) => l.power(r).into(),
+            (Logical(l), Numeric(r)) => l.power(r).into(),
+            (Logical(l), Integer(r)) => l.power(r).into(),
+            (Logical(l), Logical(r)) => l.power(r).into(),
             _ => todo!(),
         }
     }
 }
 
-pub trait VecPartialCmp {
-    type CmpOutput;
+pub trait VecPartialCmp<Rhs> {
     type Output;
-    fn vec_partial_cmp(self, rhs: Self) -> Self::CmpOutput;
-    fn vec_gt(self, rhs: Self) -> Self::Output;
-    fn vec_gte(self, rhs: Self) -> Self::Output;
-    fn vec_lt(self, rhs: Self) -> Self::Output;
-    fn vec_lte(self, rhs: Self) -> Self::Output;
-    fn vec_eq(self, rhs: Self) -> Self::Output;
-    fn vec_neq(self, rhs: Self) -> Self::Output;
+    fn vec_gt(self, rhs: Rhs) -> Self::Output;
+    fn vec_gte(self, rhs: Rhs) -> Self::Output;
+    fn vec_lt(self, rhs: Rhs) -> Self::Output;
+    fn vec_lte(self, rhs: Rhs) -> Self::Output;
+    fn vec_eq(self, rhs: Rhs) -> Self::Output;
+    fn vec_neq(self, rhs: Rhs) -> Self::Output;
 }
 
-impl VecPartialCmp for Vector {
-    type CmpOutput = Vec<Option<std::cmp::Ordering>>;
+impl VecPartialCmp<Vector> for Vector {
     type Output = Vector;
-
-    fn vec_partial_cmp(self, rhs: Self) -> Self::CmpOutput {
-        use Vector::*;
-
-        fn f<L, R, LR>(l: Vec<OptionNA<L>>, r: Vec<OptionNA<R>>) -> Vec<Option<std::cmp::Ordering>>
-        where
-            L: CoercibleInto<LR> + Clone,
-            R: CoercibleInto<LR> + Clone,
-            (L, R): CommonCmp<LR>,
-            LR: PartialOrd,
-        {
-            zip_recycle(l.into_iter(), r.into_iter())
-                .map(|pair| match pair {
-                    (OptionNA::Some(l), OptionNA::Some(r)) => {
-                        let l = CoercibleInto::<LR>::coerce_into(l);
-                        let r = CoercibleInto::<LR>::coerce_into(r);
-                        l.partial_cmp(&r)
-                    }
-                    _ => None,
-                })
-                .collect()
-        }
-
-        match (self, rhs) {
-            (Numeric(l), Numeric(r)) => f(l, r),
-            (Numeric(l), Integer(r)) => f(l, r),
-            (Numeric(l), Logical(r)) => f(l, r),
-            (Numeric(l), Character(r)) => f(l, r),
-            (Integer(l), Numeric(r)) => f(l, r),
-            (Integer(l), Integer(r)) => f(l, r),
-            (Integer(l), Logical(r)) => f(l, r),
-            (Integer(l), Character(r)) => f(l, r),
-            (Logical(l), Numeric(r)) => f(l, r),
-            (Logical(l), Integer(r)) => f(l, r),
-            (Logical(l), Logical(r)) => f(l, r),
-            (Logical(l), Character(r)) => f(l, r),
-            (Character(l), Numeric(r)) => f(l, r),
-            (Character(l), Integer(r)) => f(l, r),
-            (Character(l), Logical(r)) => f(l, r),
-            (Character(l), Character(r)) => f(l, r),
-        }
-    }
-
     fn vec_gt(self, rhs: Self) -> Self::Output {
-        use std::cmp::Ordering::*;
-        Vector::Logical(
-            self.vec_partial_cmp(rhs)
-                .into_iter()
-                .map(|i| match i {
-                    Some(Greater) => OptionNA::Some(true),
-                    Some(_) => OptionNA::Some(false),
-                    None => OptionNA::NA,
-                })
-                .collect(),
-        )
+        use Vector::*;
+        match (self, rhs) {
+            (Numeric(l), Numeric(r)) => l.vec_gt(r).into(),
+            (Numeric(l), Integer(r)) => l.vec_gt(r).into(),
+            (Numeric(l), Logical(r)) => l.vec_gt(r).into(),
+            (Numeric(l), Character(r)) => l.vec_gt(r).into(),
+            (Integer(l), Numeric(r)) => l.vec_gt(r).into(),
+            (Integer(l), Integer(r)) => l.vec_gt(r).into(),
+            (Integer(l), Logical(r)) => l.vec_gt(r).into(),
+            (Integer(l), Character(r)) => l.vec_gt(r).into(),
+            (Logical(l), Numeric(r)) => l.vec_gt(r).into(),
+            (Logical(l), Integer(r)) => l.vec_gt(r).into(),
+            (Logical(l), Logical(r)) => l.vec_gt(r).into(),
+            (Logical(l), Character(r)) => l.vec_gt(r).into(),
+            (Character(l), Numeric(r)) => l.vec_gt(r).into(),
+            (Character(l), Integer(r)) => l.vec_gt(r).into(),
+            (Character(l), Logical(r)) => l.vec_gt(r).into(),
+            (Character(l), Character(r)) => l.vec_gt(r).into(),
+        }
     }
 
     fn vec_gte(self, rhs: Self) -> Self::Output {
-        use std::cmp::Ordering::*;
-        Vector::Logical(
-            self.vec_partial_cmp(rhs)
-                .into_iter()
-                .map(|i| match i {
-                    Some(Greater | Equal) => OptionNA::Some(true),
-                    Some(_) => OptionNA::Some(false),
-                    None => OptionNA::NA,
-                })
-                .collect(),
-        )
+        use Vector::*;
+        match (self, rhs) {
+            (Numeric(l), Numeric(r)) => l.vec_gte(r).into(),
+            (Numeric(l), Integer(r)) => l.vec_gte(r).into(),
+            (Numeric(l), Logical(r)) => l.vec_gte(r).into(),
+            (Numeric(l), Character(r)) => l.vec_gte(r).into(),
+            (Integer(l), Numeric(r)) => l.vec_gte(r).into(),
+            (Integer(l), Integer(r)) => l.vec_gte(r).into(),
+            (Integer(l), Logical(r)) => l.vec_gte(r).into(),
+            (Integer(l), Character(r)) => l.vec_gte(r).into(),
+            (Logical(l), Numeric(r)) => l.vec_gte(r).into(),
+            (Logical(l), Integer(r)) => l.vec_gte(r).into(),
+            (Logical(l), Logical(r)) => l.vec_gte(r).into(),
+            (Logical(l), Character(r)) => l.vec_gte(r).into(),
+            (Character(l), Numeric(r)) => l.vec_gte(r).into(),
+            (Character(l), Integer(r)) => l.vec_gte(r).into(),
+            (Character(l), Logical(r)) => l.vec_gte(r).into(),
+            (Character(l), Character(r)) => l.vec_gte(r).into(),
+        }
     }
 
     fn vec_lt(self, rhs: Self) -> Self::Output {
-        use std::cmp::Ordering::*;
-        Vector::Logical(
-            self.vec_partial_cmp(rhs)
-                .into_iter()
-                .map(|i| match i {
-                    Some(Less) => OptionNA::Some(true),
-                    Some(_) => OptionNA::Some(false),
-                    None => OptionNA::NA,
-                })
-                .collect(),
-        )
+        use Vector::*;
+        match (self, rhs) {
+            (Numeric(l), Numeric(r)) => l.vec_lt(r).into(),
+            (Numeric(l), Integer(r)) => l.vec_lt(r).into(),
+            (Numeric(l), Logical(r)) => l.vec_lt(r).into(),
+            (Numeric(l), Character(r)) => l.vec_lt(r).into(),
+            (Integer(l), Numeric(r)) => l.vec_lt(r).into(),
+            (Integer(l), Integer(r)) => l.vec_lt(r).into(),
+            (Integer(l), Logical(r)) => l.vec_lt(r).into(),
+            (Integer(l), Character(r)) => l.vec_lt(r).into(),
+            (Logical(l), Numeric(r)) => l.vec_lt(r).into(),
+            (Logical(l), Integer(r)) => l.vec_lt(r).into(),
+            (Logical(l), Logical(r)) => l.vec_lt(r).into(),
+            (Logical(l), Character(r)) => l.vec_lt(r).into(),
+            (Character(l), Numeric(r)) => l.vec_lt(r).into(),
+            (Character(l), Integer(r)) => l.vec_lt(r).into(),
+            (Character(l), Logical(r)) => l.vec_lt(r).into(),
+            (Character(l), Character(r)) => l.vec_lt(r).into(),
+        }
     }
 
     fn vec_lte(self, rhs: Self) -> Self::Output {
-        use std::cmp::Ordering::*;
-        Vector::Logical(
-            self.vec_partial_cmp(rhs)
-                .into_iter()
-                .map(|i| match i {
-                    Some(Less | Equal) => OptionNA::Some(true),
-                    Some(_) => OptionNA::Some(false),
-                    None => OptionNA::NA,
-                })
-                .collect(),
-        )
+        use Vector::*;
+        match (self, rhs) {
+            (Numeric(l), Numeric(r)) => l.vec_lte(r).into(),
+            (Numeric(l), Integer(r)) => l.vec_lte(r).into(),
+            (Numeric(l), Logical(r)) => l.vec_lte(r).into(),
+            (Numeric(l), Character(r)) => l.vec_lte(r).into(),
+            (Integer(l), Numeric(r)) => l.vec_lte(r).into(),
+            (Integer(l), Integer(r)) => l.vec_lte(r).into(),
+            (Integer(l), Logical(r)) => l.vec_lte(r).into(),
+            (Integer(l), Character(r)) => l.vec_lte(r).into(),
+            (Logical(l), Numeric(r)) => l.vec_lte(r).into(),
+            (Logical(l), Integer(r)) => l.vec_lte(r).into(),
+            (Logical(l), Logical(r)) => l.vec_lte(r).into(),
+            (Logical(l), Character(r)) => l.vec_lte(r).into(),
+            (Character(l), Numeric(r)) => l.vec_lte(r).into(),
+            (Character(l), Integer(r)) => l.vec_lte(r).into(),
+            (Character(l), Logical(r)) => l.vec_lte(r).into(),
+            (Character(l), Character(r)) => l.vec_lte(r).into(),
+        }
     }
 
     fn vec_eq(self, rhs: Self) -> Self::Output {
-        use std::cmp::Ordering::*;
-        Vector::Logical(
-            self.vec_partial_cmp(rhs)
-                .into_iter()
-                .map(|i| match i {
-                    Some(Equal) => OptionNA::Some(true),
-                    Some(_) => OptionNA::Some(false),
-                    None => OptionNA::NA,
-                })
-                .collect(),
-        )
+        use Vector::*;
+        match (self, rhs) {
+            (Numeric(l), Numeric(r)) => l.vec_eq(r).into(),
+            (Numeric(l), Integer(r)) => l.vec_eq(r).into(),
+            (Numeric(l), Logical(r)) => l.vec_eq(r).into(),
+            (Numeric(l), Character(r)) => l.vec_eq(r).into(),
+            (Integer(l), Numeric(r)) => l.vec_eq(r).into(),
+            (Integer(l), Integer(r)) => l.vec_eq(r).into(),
+            (Integer(l), Logical(r)) => l.vec_eq(r).into(),
+            (Integer(l), Character(r)) => l.vec_eq(r).into(),
+            (Logical(l), Numeric(r)) => l.vec_eq(r).into(),
+            (Logical(l), Integer(r)) => l.vec_eq(r).into(),
+            (Logical(l), Logical(r)) => l.vec_eq(r).into(),
+            (Logical(l), Character(r)) => l.vec_eq(r).into(),
+            (Character(l), Numeric(r)) => l.vec_eq(r).into(),
+            (Character(l), Integer(r)) => l.vec_eq(r).into(),
+            (Character(l), Logical(r)) => l.vec_eq(r).into(),
+            (Character(l), Character(r)) => l.vec_eq(r).into(),
+        }
     }
 
     fn vec_neq(self, rhs: Self) -> Self::Output {
-        use std::cmp::Ordering::*;
-        Vector::Logical(
-            self.vec_partial_cmp(rhs)
-                .into_iter()
-                .map(|i| match i {
-                    Some(Equal) => OptionNA::Some(false),
-                    Some(_) => OptionNA::Some(true),
-                    None => OptionNA::NA,
-                })
-                .collect(),
-        )
+        use Vector::*;
+        match (self, rhs) {
+            (Numeric(l), Numeric(r)) => l.vec_neq(r).into(),
+            (Numeric(l), Integer(r)) => l.vec_neq(r).into(),
+            (Numeric(l), Logical(r)) => l.vec_neq(r).into(),
+            (Numeric(l), Character(r)) => l.vec_neq(r).into(),
+            (Integer(l), Numeric(r)) => l.vec_neq(r).into(),
+            (Integer(l), Integer(r)) => l.vec_neq(r).into(),
+            (Integer(l), Logical(r)) => l.vec_neq(r).into(),
+            (Integer(l), Character(r)) => l.vec_neq(r).into(),
+            (Logical(l), Numeric(r)) => l.vec_neq(r).into(),
+            (Logical(l), Integer(r)) => l.vec_neq(r).into(),
+            (Logical(l), Logical(r)) => l.vec_neq(r).into(),
+            (Logical(l), Character(r)) => l.vec_neq(r).into(),
+            (Character(l), Numeric(r)) => l.vec_neq(r).into(),
+            (Character(l), Integer(r)) => l.vec_neq(r).into(),
+            (Character(l), Logical(r)) => l.vec_neq(r).into(),
+            (Character(l), Character(r)) => l.vec_neq(r).into(),
+        }
     }
 }
 
@@ -866,32 +739,16 @@ impl std::ops::Rem for Vector {
     type Output = Vector;
     fn rem(self, rhs: Self) -> Self::Output {
         use Vector::*;
-
-        fn f<L, R, LNum, RNum, LRNum>(l: Vec<L>, r: Vec<R>) -> Vector
-        where
-            L: IntoNumeric<LNum> + Clone,
-            R: IntoNumeric<RNum> + Clone,
-            (LNum, RNum): CommonNum<LRNum>,
-            Vector: From<Vec<<LRNum as std::ops::Rem>::Output>>,
-            LRNum: std::ops::Rem,
-        {
-            Vector::from(
-                map_common_mul_numeric(zip_recycle(l, r))
-                    .map(|(l, r)| l.rem(r))
-                    .collect::<Vec<_>>(),
-            )
-        }
-
         match (self, rhs) {
-            (Numeric(l), Numeric(r)) => f(l, r),
-            (Numeric(l), Integer(r)) => f(l, r),
-            (Numeric(l), Logical(r)) => f(l, r),
-            (Integer(l), Numeric(r)) => f(l, r),
-            (Integer(l), Integer(r)) => f(l, r),
-            (Integer(l), Logical(r)) => f(l, r),
-            (Logical(l), Numeric(r)) => f(l, r),
-            (Logical(l), Integer(r)) => f(l, r),
-            (Logical(l), Logical(r)) => f(l, r),
+            (Numeric(l), Numeric(r)) => l.rem(r).into(),
+            (Numeric(l), Integer(r)) => l.rem(r).into(),
+            (Numeric(l), Logical(r)) => l.rem(r).into(),
+            (Integer(l), Numeric(r)) => l.rem(r).into(),
+            (Integer(l), Integer(r)) => l.rem(r).into(),
+            (Integer(l), Logical(r)) => l.rem(r).into(),
+            (Logical(l), Numeric(r)) => l.rem(r).into(),
+            (Logical(l), Integer(r)) => l.rem(r).into(),
+            (Logical(l), Logical(r)) => l.rem(r).into(),
             _ => todo!(),
         }
     }
@@ -900,19 +757,24 @@ impl std::ops::Rem for Vector {
 impl std::ops::BitOr for Vector {
     type Output = Vector;
     fn bitor(self, rhs: Self) -> Self::Output {
-        use OptionNA::*;
         use Vector::*;
-
-        match (self.as_logical(), rhs.as_logical()) {
-            (Logical(l), Logical(r)) => Vector::Logical(
-                zip_recycle(l.into_iter(), r.into_iter())
-                    .map(|(l, r)| match (l, r) {
-                        (Some(l), Some(r)) => Some(l || r),
-                        _ => NA,
-                    })
-                    .collect::<Vec<_>>(),
-            ),
-            _ => todo!(),
+        match (self, rhs) {
+            (Numeric(l), Numeric(r)) => l.bitor(r).into(),
+            (Numeric(l), Integer(r)) => l.bitor(r).into(),
+            (Numeric(l), Logical(r)) => l.bitor(r).into(),
+            (Numeric(l), Character(r)) => l.bitor(r).into(),
+            (Integer(l), Numeric(r)) => l.bitor(r).into(),
+            (Integer(l), Integer(r)) => l.bitor(r).into(),
+            (Integer(l), Logical(r)) => l.bitor(r).into(),
+            (Integer(l), Character(r)) => l.bitor(r).into(),
+            (Logical(l), Numeric(r)) => l.bitor(r).into(),
+            (Logical(l), Integer(r)) => l.bitor(r).into(),
+            (Logical(l), Logical(r)) => l.bitor(r).into(),
+            (Logical(l), Character(r)) => l.bitor(r).into(),
+            (Character(l), Numeric(r)) => l.bitor(r).into(),
+            (Character(l), Integer(r)) => l.bitor(r).into(),
+            (Character(l), Logical(r)) => l.bitor(r).into(),
+            (Character(l), Character(r)) => l.bitor(r).into(),
         }
     }
 }
@@ -920,19 +782,24 @@ impl std::ops::BitOr for Vector {
 impl std::ops::BitAnd for Vector {
     type Output = Vector;
     fn bitand(self, rhs: Self) -> Self::Output {
-        use OptionNA::*;
         use Vector::*;
-
-        match (self.as_logical(), rhs.as_logical()) {
-            (Logical(l), Logical(r)) => Vector::Logical(
-                zip_recycle(l.into_iter(), r.into_iter())
-                    .map(|(l, r)| match (l, r) {
-                        (Some(l), Some(r)) => Some(l && r),
-                        _ => NA,
-                    })
-                    .collect::<Vec<_>>(),
-            ),
-            _ => todo!(),
+        match (self, rhs) {
+            (Numeric(l), Numeric(r)) => l.bitand(r).into(),
+            (Numeric(l), Integer(r)) => l.bitand(r).into(),
+            (Numeric(l), Logical(r)) => l.bitand(r).into(),
+            (Numeric(l), Character(r)) => l.bitand(r).into(),
+            (Integer(l), Numeric(r)) => l.bitand(r).into(),
+            (Integer(l), Integer(r)) => l.bitand(r).into(),
+            (Integer(l), Logical(r)) => l.bitand(r).into(),
+            (Integer(l), Character(r)) => l.bitand(r).into(),
+            (Logical(l), Numeric(r)) => l.bitand(r).into(),
+            (Logical(l), Integer(r)) => l.bitand(r).into(),
+            (Logical(l), Logical(r)) => l.bitand(r).into(),
+            (Logical(l), Character(r)) => l.bitand(r).into(),
+            (Character(l), Numeric(r)) => l.bitand(r).into(),
+            (Character(l), Integer(r)) => l.bitand(r).into(),
+            (Character(l), Logical(r)) => l.bitand(r).into(),
+            (Character(l), Character(r)) => l.bitand(r).into(),
         }
     }
 }


### PR DESCRIPTION
After a few separate attempts to get #46 working, I realized that the ethos of that refactor was leading toward a pretty wild overhaul that I wasn't quite prepared for. To keep things a bit more manageable, I split off just the part that felt most pressing to me - being able to assign by mutable slice. 

I'm really happy with how that part came together. The subsetting works really nicely and the list of R objects just dispatches to the right handler for internal equivalents to most top level actions (get-by-index, assign-by-index, call). 

In the process, I learned a lot about how to write generic code. Writing the vector representations as type-generic felt very comfortable, but it means that at _some point_ we either have to have R know which types are in each vec, or we have to make the whole R object layer generic. This quickly gets to a place where we introduce dynamic dispatch on trait objects to handle heterogeneous lists. That said, having a generic interface for any R object that implements things like "get-by-index", "get-by-name" and even "call with these args" felt quite natural! At the end of the day, though, I didn't feel totally comfortable introducing dynamic dispatch and working with all the up/down casting to get it to work. After spending nearly a day trying, it felt like too much of leap without enough familiarity to commit to a total refactor. Instead, I tried to introduce this feature with minimal changes to break up the major changes a bit. 

So that brings us to what the solution looks like. I feel like the developer-facing surface looks nice, and the internal vector tools feel nice, but somewhere in the middle where they meet up it's just a ton of boilerplate to make things work. R objects are still an enum of object types, the most important of which is the vector for this work. Vectors still have their 4 types/modes (numeric, integer, etc). Any lower and any handling of vectors is entirely generic. Numeric and logical operations on vectors have a little type hierarchy they follow when trying to decide what the output should be, and it all happens automatically. I explored some cool concepts with how this type hierarchy is articulated in #46, but the method used here is a bit more brute-force. 

After all these changes, the compile time and size approximately doubled, which I think is due to the introduction of a few extra stdlib modules and the wealth of pairwise operations that are now permitted. This was a bit of a surprise, but I think the feature is not really negotiable. I'll have to learn a bit about what all drives these factors before I would have any idea what to do about it.