### PR TITLE
Destructuring assignment

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,17 @@
+# dev
+
+## Major Changes
+
+* Added simplest-case destructuring assignment.
+
+  ```r
+  (x, y) <- list(a = 1, b = 2)
+  x
+  # [1] 1
+  y
+  # [1] 2
+  ```
+
 # 0.3.0 "Days of Abandon"
 
 ## Major Changes

--- a/src/callable/operators.rs
+++ b/src/callable/operators.rs
@@ -12,25 +12,7 @@ pub struct InfixAssign;
 impl Callable for InfixAssign {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = args.unnamed_binary_args();
-
-        use Expr::*;
-        match lhs {
-            String(s) | Symbol(s) => {
-                let value = stack.eval(rhs)?;
-                stack.last_frame().env.insert(s, value.clone());
-                Ok(value)
-            }
-            Call(what, mut args) => match *what {
-                String(s) | Symbol(s) => {
-                    args.insert(0, rhs);
-                    let s = format!("{}<-", s);
-                    stack.eval(Call(Box::new(Symbol(s)), args))
-                }
-                Primitive(p) => p.call_assign(rhs, args, stack),
-                _ => unimplemented!("cannot assign to that!"),
-            },
-            _ => unimplemented!("cannot assign to that!"),
-        }
+        stack.assign_lazy(lhs, rhs)
     }
 }
 

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -167,7 +167,7 @@
         number_trailing = { "." ~ ASCII_DIGIT+ }
 
     integer_expr = _{ integer ~ "L" }
-        integer = @{ "-"? ~ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+        integer = @{ "-"? ~ ( ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* | "0" ) }
 
     string_expr = _{ "\"" ~ double_quoted_string ~ "\"" | "'" ~ single_quoted_string ~ "'" }
         single_quoted_string = @{ single_quoted_string_char* }
@@ -182,10 +182,10 @@
     symbol = _{ symbol_with_backticks | symbol_ident }
         symbol_with_backticks = _{ "`" ~ symbol_backticked ~ "`" }
         symbol_backticked = ${ ( !"`" ~ ANY )* }
-        symbol_ident = ${ ( ASCII_ALPHA | "." | "_" ) ~ ( ASCII_ALPHANUMERIC | "." | "_" )* }
+        symbol_ident = ${ ( ASCII_ALPHA | "_" ) ~ ( ASCII_ALPHANUMERIC | "_" )* }
 
     list = { "(" ~ pairs ~ ")" }
-        pairs = _{ ( ( WS* ~ elem? ~ WS* ~ "," )* ~ WS* ~ elem? )? ~ WS* }
+        pairs = _{ ( ( WS* ~ elem ~ WS* ~ "," )* ~ WS* ~ elem? )? ~ WS* }
         ellipsis = { "..." }
         elem = _{ ellipsis | named | expr }
         named = { symbol ~ WS* ~ "=" ~ WS* ~ expr? }

--- a/src/object/list.rs
+++ b/src/object/list.rs
@@ -194,7 +194,7 @@ impl List {
     }
 
     pub fn try_get(&self, index: Obj) -> EvalResult {
-        let err = RError::Other("Cannot use object for indexing.".to_string());
+        let err = RError::Other("Cannot use object for indexing".to_string());
         match index.as_vector()? {
             Obj::Vector(v) => Ok(Obj::List(self.subset(v.try_into()?))),
             _ => Err(err.into()),
@@ -202,7 +202,9 @@ impl List {
     }
 
     pub fn try_get_inner(&self, index: Obj) -> EvalResult {
-        let err = RError::Other("Cannot use object for indexing.".to_string());
+        let err_invalid = RError::Other("Cannot use object for indexing".to_string());
+        let err_index_invalid = RError::Other("Index out of bounds".to_string());
+
         match index.as_vector()? {
             Obj::Vector(v) if v.len() == 1 => {
                 let Subsets(mut subsets) = self.subsets.clone();
@@ -216,12 +218,12 @@ impl List {
                     self.values
                         .borrow()
                         .get(i)
-                        .map_or(Err(err.into()), |(_, i)| Ok(i.clone()))
+                        .map_or(Err(err_index_invalid.into()), |(_, i)| Ok(i.clone()))
                 } else {
                     Ok(Obj::Null)
                 }
             }
-            _ => Err(err.into()),
+            _ => Err(err_invalid.into()),
         }
     }
 

--- a/src/object/vector/subsets.rs
+++ b/src/object/vector/subsets.rs
@@ -68,8 +68,6 @@ impl IntoIterator for NamedSubsets {
             match subset {
                 Subset::Names(names) => {
                     use super::OptionNA;
-                    const NOTFOUND: (usize, Option<usize>) = (0, None);
-
                     let snames = self.names.borrow();
 
                     // grab indices within subset to find first named index
@@ -96,19 +94,19 @@ impl IntoIterator for NamedSubsets {
                     let named_indices = names
                         .borrow()
                         .iter()
-                        .map(|name| match name {
-                            OptionNA::NA => NOTFOUND,
+                        .filter_map(|name| match name {
+                            OptionNA::NA => None,
                             OptionNA::Some(name) => snames
                                 .get(name)
                                 .and_then(|name_indices| {
                                     for i in name_indices {
                                         if subset_indices.contains(i) {
-                                            return Some((*i, Some(*i)));
+                                            return Some(Some((*i, Some(*i))));
                                         }
                                     }
-                                    Some(NOTFOUND)
+                                    None
                                 })
-                                .unwrap_or(NOTFOUND),
+                                .unwrap_or(None),
                         })
                         .collect::<Vec<_>>();
 


### PR DESCRIPTION
* Adds destructuring assignment `(x, y) <- (a = 1, b = 2)`. I hope to expand this in the future for arbitrarily nested built-in data type matching, but for now it only works with named and unnamed symbols. 

Minor changes

* Updated pairs syntax (used for vectors and lists) to disallow more than one trailing comma
* Disallow `.`s in symbols! After many years of R this still feels weird and is used for both names and meaningful S3 method notation.
* Trying to index into a list with a name it does not contain no longer erroneously returns the first element.