### PR TITLE
Allow whitespace between prefix/postfix operators

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -58,8 +58,8 @@
         comment = _{ "#" ~ ( !NEWLINE ~ !eoi ~ ANY )* }
 
         atomic = _{ prefixed | standalone }
-            prefixed = { prefix* ~ postfixed }
-            postfixed = { atom ~ postfix* }
+            prefixed = { prefix* ~ WS* ~ postfixed }
+            postfixed = { atom ~ WS_NO_NL* ~ postfix* }
 
         infix = _{ 
                 assign | 
@@ -167,8 +167,8 @@
 
 // atomic value types
 
-    number = @{ "-"? ~ (number_leading | number_trailing) }
-        number_leading = { ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT*)? }
+    number = @{ number_leading | number_trailing }
+        number_leading = { ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ number_trailing? }
         number_trailing = { "." ~ ASCII_DIGIT+ }
 
     integer_expr = _{ integer ~ "L" }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -168,7 +168,7 @@
 // atomic value types
 
     number = @{ number_leading | number_trailing }
-        number_leading = { ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ number_trailing? }
+        number_leading = { ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT*)? }
         number_trailing = { "." ~ ASCII_DIGIT+ }
 
     integer_expr = _{ integer ~ "L" }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -339,3 +339,18 @@ fn parse_list(pair: Pair<Rule>) -> ParseResult {
     let args = parse_pairlist(pair)?;
     Ok(Expr::List(args))
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{r, r_expect};
+
+    #[test]
+    fn prefix_with_space() {
+        r_expect! { - 1 + 1 == 0 }
+    }
+
+    #[test]
+    fn postfix_with_space() {
+        r_expect! { c (1) == true }
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -342,15 +342,21 @@ fn parse_list(pair: Pair<Rule>) -> ParseResult {
 
 #[cfg(test)]
 mod test {
-    use crate::{r, r_expect};
+    use crate::r;
 
     #[test]
     fn prefix_with_space() {
-        r_expect! { - 1 + 1 == 0 }
+        assert_eq! {
+            r! {{"- 1"}},
+            r! { -1 }
+        }
     }
 
     #[test]
     fn postfix_with_space() {
-        r_expect! { c (1) == true }
+        assert_eq! {
+            r! {{"c (1)"}},
+            r! {{"c(1)"}}
+        }
     }
 }


### PR DESCRIPTION
Closes #68 

This should allow any whitespace between a negative sign and the rest of an expression, and non-newline whitespace between an expression and postfix operators (`(`, `[[`, `[`)

For example, this will now parse `- 1` and `q ()`

@sebffischer tagging for interest in case you'd like to learn a bit about the parser