### PR TITLE
Feat/primitive sum

### DIFF
--- a/src/callable/builtins.rs
+++ b/src/callable/builtins.rs
@@ -52,6 +52,7 @@ lazy_static! {
             ("quote", Box::new(PrimitiveQuote) as Box<dyn Builtin>),
             ("rnorm", Box::new(PrimitiveRnorm) as Box<dyn Builtin>),
             ("runif", Box::new(PrimitiveRunif) as Box<dyn Builtin>),
+            ("sum", Box::new(PrimitiveSum) as Box<dyn Builtin>),
             // builtins end
         ])
     };

--- a/src/callable/primitive/mod.rs
+++ b/src/callable/primitive/mod.rs
@@ -24,3 +24,5 @@ mod rnorm;
 pub use rnorm::PrimitiveRnorm;
 mod runif;
 pub use runif::PrimitiveRunif;
+mod sum;
+pub use sum::PrimitiveSum;

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -86,10 +86,10 @@ impl Callable for PrimitiveSum {
                                     }
                                 }
                             },
-                            _ => unreachable!(),
+                            _ => return internal_err!(),
                         };
                     }
-                    _ => unreachable!(),
+                    _ => return internal_err!(),
                 }
             }
             EvalResult::Ok(Obj::Vector(Vector::from(Rep::from(vec![sum]))))

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -41,7 +41,7 @@ impl Callable for PrimitiveSum {
                 }
                 _ => {
                     return EvalResult::Err(Signal::Error(Error::Other(String::from(
-                        "All inputs must be of type logical, numeric or character.",
+                        "All inputs must be of type numeric, integer or logical.",
                     ))))
                 }
             }

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -2,10 +2,10 @@ use r_derive::*;
 
 use crate::callable::core::*;
 use crate::error::*;
+use crate::internal_err;
 use crate::lang::*;
 use crate::object::rep::Rep;
 use crate::object::*;
-use crate::internal_err;
 
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "sum")]

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -122,10 +122,10 @@ impl Callable for PrimitiveSum {
                                     }
                                 }
                             },
-                            _ => unreachable!(),
+                            _ => return internal_err!(),
                         };
                     }
-                    _ => unreachable!(),
+                    _ => return internal_err!(),
                 }
             }
             EvalResult::Ok(Obj::Vector(Vector::from(Rep::from(vec![sum]))))

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -57,7 +57,8 @@ impl Callable for PrimitiveSum {
                                 for x in repr.inner().borrow().iter() {
                                     match *x {
                                         OptionNA::NA => {
-                                            let rep: Rep<OptionNA<f64>> = Rep::from(vec![OptionNA::NA]);
+                                            let rep: Rep<OptionNA<f64>> =
+                                                Rep::from(vec![OptionNA::NA]);
                                             return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
                                         }
                                         OptionNA::Some(x) => sum += x as i32 as f64,
@@ -68,24 +69,26 @@ impl Callable for PrimitiveSum {
                                 for x in repr.inner().borrow().iter() {
                                     match *x {
                                         OptionNA::NA => {
-                                            let rep: Rep<OptionNA<f64>> = Rep::from(vec![OptionNA::NA]);
+                                            let rep: Rep<OptionNA<f64>> =
+                                                Rep::from(vec![OptionNA::NA]);
                                             return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
                                         }
                                         OptionNA::Some(x) => sum += x as f64,
                                     }
                                 }
-                            },
+                            }
                             Vector::Numeric(repr) => {
                                 for x in repr.inner().borrow().iter() {
                                     match *x {
                                         OptionNA::NA => {
-                                            let rep: Rep<OptionNA<f64>> = Rep::from(vec![OptionNA::NA]);
+                                            let rep: Rep<OptionNA<f64>> =
+                                                Rep::from(vec![OptionNA::NA]);
                                             return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
                                         }
                                         OptionNA::Some(x) => sum += x,
                                     }
                                 }
-                            },
+                            }
                             _ => return internal_err!(),
                         };
                     }
@@ -104,7 +107,8 @@ impl Callable for PrimitiveSum {
                                 for x in repr.inner().borrow().iter() {
                                     match *x {
                                         OptionNA::NA => {
-                                            let rep: Rep<OptionNA<i32>> = Rep::from(vec![OptionNA::NA]);
+                                            let rep: Rep<OptionNA<i32>> =
+                                                Rep::from(vec![OptionNA::NA]);
                                             return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
                                         }
                                         OptionNA::Some(x) => sum += x as i32,
@@ -115,13 +119,14 @@ impl Callable for PrimitiveSum {
                                 for x in repr.inner().borrow().iter() {
                                     match *x {
                                         OptionNA::NA => {
-                                            let rep: Rep<OptionNA<i32>> = Rep::from(vec![OptionNA::NA]);
+                                            let rep: Rep<OptionNA<i32>> =
+                                                Rep::from(vec![OptionNA::NA]);
                                             return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
                                         }
                                         OptionNA::Some(x) => sum += x,
                                     }
                                 }
-                            },
+                            }
                             _ => return internal_err!(),
                         };
                     }
@@ -210,9 +215,6 @@ mod tests {
 
     #[test]
     fn sum_named_args() {
-        assert_eq!(
-            r! {{"sum(a = 1, b = 2)"}},
-            r! {{"3"}},
-        )
+        assert_eq!(r! {{"sum(a = 1, b = 2)"}}, r! {{"3"}},)
     }
 }

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -22,8 +22,7 @@ impl Callable for PrimitiveSum {
             return EvalResult::Ok(Obj::Vector(Vector::from(Rep::from(vec![0.0]))));
         }
 
-        let objects: Vec<Obj> = force_closures(ellipsis, stack)
-            .unwrap()
+        let objects: Vec<Obj> = force_closures(ellipsis, stack)?
             .into_iter()
             .map(|(_, value)| value)
             .collect();

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -158,4 +158,12 @@ mod tests {
             r! {{"1"}},
         )
     }
+
+    #[test]
+    fn sum_named_args() {
+        assert_eq!(
+            r! {{"sum(a = 1, b = 2)"}},
+            r! {{"3"}},
+        )
+    }
 }

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -5,6 +5,7 @@ use crate::error::*;
 use crate::lang::*;
 use crate::object::rep::Rep;
 use crate::object::*;
+use crate::internal_err;
 
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "sum")]

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -53,22 +53,42 @@ impl Callable for PrimitiveSum {
             for obj in objects {
                 match obj {
                     Obj::Vector(vect) => {
-                        let rep = match vect {
-                            Vector::Numeric(repr) => repr.as_numeric(),
-                            Vector::Logical(repr) => repr.as_numeric(),
-                            Vector::Integer(repr) => repr.as_numeric(),
+                        match vect {
+                            Vector::Logical(repr) => {
+                                for x in repr.inner().borrow().iter() {
+                                    match *x {
+                                        OptionNA::NA => {
+                                            let rep: Rep<OptionNA<f64>> = Rep::from(vec![OptionNA::NA]);
+                                            return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
+                                        }
+                                        OptionNA::Some(x) => sum += x as i32 as f64,
+                                    }
+                                }
+                            }
+                            Vector::Integer(repr) => {
+                                for x in repr.inner().borrow().iter() {
+                                    match *x {
+                                        OptionNA::NA => {
+                                            let rep: Rep<OptionNA<f64>> = Rep::from(vec![OptionNA::NA]);
+                                            return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
+                                        }
+                                        OptionNA::Some(x) => sum += x as f64,
+                                    }
+                                }
+                            },
+                            Vector::Numeric(repr) => {
+                                for x in repr.inner().borrow().iter() {
+                                    match *x {
+                                        OptionNA::NA => {
+                                            let rep: Rep<OptionNA<f64>> = Rep::from(vec![OptionNA::NA]);
+                                            return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
+                                        }
+                                        OptionNA::Some(x) => sum += x,
+                                    }
+                                }
+                            },
                             _ => unreachable!(),
                         };
-                        let xs = rep.inner();
-                        for x in xs.borrow().iter() {
-                            match *x {
-                                OptionNA::NA => {
-                                    let rep: Rep<OptionNA<f64>> = Rep::from(vec![OptionNA::NA]);
-                                    return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
-                                }
-                                OptionNA::Some(x) => sum += x,
-                            }
-                        }
                     }
                     _ => unreachable!(),
                 }
@@ -80,21 +100,31 @@ impl Callable for PrimitiveSum {
             for obj in objects {
                 match obj {
                     Obj::Vector(vect) => {
-                        let rep = match vect {
-                            Vector::Logical(repr) => repr.as_integer(),
-                            Vector::Integer(repr) => repr.as_integer(),
+                        match vect {
+                            Vector::Logical(repr) => {
+                                for x in repr.inner().borrow().iter() {
+                                    match *x {
+                                        OptionNA::NA => {
+                                            let rep: Rep<OptionNA<i32>> = Rep::from(vec![OptionNA::NA]);
+                                            return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
+                                        }
+                                        OptionNA::Some(x) => sum += x as i32,
+                                    }
+                                }
+                            }
+                            Vector::Integer(repr) => {
+                                for x in repr.inner().borrow().iter() {
+                                    match *x {
+                                        OptionNA::NA => {
+                                            let rep: Rep<OptionNA<i32>> = Rep::from(vec![OptionNA::NA]);
+                                            return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
+                                        }
+                                        OptionNA::Some(x) => sum += x,
+                                    }
+                                }
+                            },
                             _ => unreachable!(),
                         };
-                        let xs = rep.inner();
-                        for x in xs.borrow().iter() {
-                            match *x {
-                                OptionNA::NA => {
-                                    let rep: Rep<OptionNA<i32>> = Rep::from(vec![OptionNA::NA]);
-                                    return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
-                                }
-                                OptionNA::Some(x) => sum += x,
-                            }
-                        }
                     }
                     _ => unreachable!(),
                 }
@@ -111,6 +141,26 @@ mod tests {
     #[test]
     fn sum_empty() {
         assert_eq!(r! {sum()}, r! {0.0},)
+    }
+
+    // FIXME: Overly aggressive conversion to Numeric, representations for NAs
+    // #[test]
+    // fn sum_add() {
+    //     assert_eq!(r! {sum(1L, 2L)}, r! {1L + 2L});
+    // }
+    // #[test]
+    // fn sum_na_logical() {
+    //     assert_eq!(r! {sum(NA, true)}, r! {NA + 0L});
+    // }
+    //
+    // #[test]
+    // fn sum_na_integer() {
+    //     assert_eq!(r! {sum(NA, 1L)}, r! {NA * 1L});
+    // }
+
+    #[test]
+    fn sum_na_numeric() {
+        assert_eq!(r! {sum(NA, 1)}, r! {NA * 1});
     }
 
     #[test]

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -1,0 +1,161 @@
+use r_derive::*;
+
+use crate::callable::core::*;
+use crate::error::*;
+use crate::lang::*;
+use crate::object::rep::Rep;
+use crate::object::*;
+
+#[derive(Debug, Clone, PartialEq)]
+#[builtin(sym = "sum")]
+pub struct PrimitiveSum;
+
+impl Callable for PrimitiveSum {
+    fn formals(&self) -> ExprList {
+        ExprList::from(vec![(None, Expr::Ellipsis(None))])
+    }
+
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let (_, ellipsis) = self.match_arg_exprs(args, stack)?;
+
+        if ellipsis.is_empty() {
+            return EvalResult::Ok(Obj::Vector(Vector::from(Rep::from(vec![0.0]))));
+        }
+
+        let objects: Vec<Obj> = force_closures(ellipsis, stack)
+            .unwrap()
+            .into_iter()
+            .map(|(_, value)| value)
+            .collect();
+
+        let mut any_numeric: bool = false;
+
+        for obj in &objects {
+            match obj {
+                Obj::Vector(Vector::Numeric(..)) => {
+                    any_numeric = true;
+                    break;
+                }
+                Obj::Vector(Vector::Logical(..)) | Obj::Vector(Vector::Integer(..)) => {
+                    continue;
+                }
+                _ => {
+                    return EvalResult::Err(Signal::Error(Error::Other(String::from(
+                        "All inputs must be of type logical, numeric or character.",
+                    ))))
+                }
+            }
+        }
+
+        if any_numeric {
+            let mut sum: f64 = 0.0;
+
+            for obj in objects {
+                match obj {
+                    Obj::Vector(vect) => {
+                        let rep = match vect {
+                            Vector::Numeric(repr) => repr.as_numeric(),
+                            Vector::Logical(repr) => repr.as_numeric(),
+                            Vector::Integer(repr) => repr.as_numeric(),
+                            _ => unreachable!(),
+                        };
+                        let xs = rep.inner();
+                        for x in xs.borrow().iter() {
+                            match *x {
+                                OptionNA::NA => {
+                                    let rep: Rep<OptionNA<f64>> = Rep::from(vec![OptionNA::NA]);
+                                    return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
+                                }
+                                OptionNA::Some(x) => sum += x,
+                            }
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            EvalResult::Ok(Obj::Vector(Vector::from(Rep::from(vec![sum]))))
+        } else {
+            let mut sum: i32 = 0;
+
+            for obj in objects {
+                match obj {
+                    Obj::Vector(vect) => {
+                        let rep = match vect {
+                            Vector::Logical(repr) => repr.as_integer(),
+                            Vector::Integer(repr) => repr.as_integer(),
+                            _ => unreachable!(),
+                        };
+                        let xs = rep.inner();
+                        for x in xs.borrow().iter() {
+                            match *x {
+                                OptionNA::NA => {
+                                    let rep: Rep<OptionNA<i32>> = Rep::from(vec![OptionNA::NA]);
+                                    return EvalResult::Ok(Obj::Vector(Vector::from(rep)));
+                                }
+                                OptionNA::Some(x) => sum += x,
+                            }
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            EvalResult::Ok(Obj::Vector(Vector::from(Rep::from(vec![sum]))))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::r;
+
+    #[test]
+    fn sum_empty() {
+        assert_eq!(r! {sum()}, r! {0.0},)
+    }
+
+    #[test]
+    fn sum_null() {
+        assert!((r! {sum(null)}).is_err());
+    }
+
+    #[test]
+    fn sum_numeric() {
+        assert_eq!(r! {{"sum(c(1, 2), c(3, 4))"}}, r! {{"10"}})
+    }
+
+    #[test]
+    fn sum_integer() {
+        assert_eq!(r! {{"sum(1L, 2L, c(3L, 4L))"}}, r! {{"10L"}},)
+    }
+
+    #[test]
+    fn sum_logical() {
+        assert_eq!(r! {{"sum(c(true, true), false)"}}, r! {2L})
+    }
+
+    #[test]
+    fn sum_integer_numeric() {
+        assert_eq!(r! {{"sum(c(-1L, 0L), 1)"}}, r! {{"0"}},)
+    }
+
+    #[test]
+    fn sum_integer_logical() {
+        assert_eq!(
+            r! {{"sum(c(1L, 0L), 2L, c(false, false, true))"}},
+            r! {{"4L"}},
+        )
+    }
+
+    #[test]
+    fn sum_numeric_logical() {
+        assert_eq!(r! {{"sum(c(1, 4, 5), false, true)"}}, r! {{"11"}},)
+    }
+
+    #[test]
+    fn sum_integer_numeric_logical() {
+        assert_eq!(
+            r! {{"sum(c(1L, -2L), c(5, -5, 1), c(true, false))"}},
+            r! {{"1"}},
+        )
+    }
+}


### PR DESCRIPTION
This implementation definitely feels over complicated and not "quite right", so I am not sure whether this is just necessary because of rust's type system or whether (much more likely) I have used the wrong design patterns. In any case, any feedback is much appreciated!

Other comments / thoughts: 

*  Maybe the call to `.inner()` can be avoided, as we don't really have to materialize the vector but just have to loop over all the elements. I don't fully understand the subsetting mechanism of the vector type yet, so I just went with the naive solution. I guess I could implement the `Iter` trait for the `Vector` type?
* Also, the handling of NAs seems to be quite costly. While this is arguably an essential feature when representing statistical data, maybe we could at some later point have special variants of the vectors without NAs to make operations on them faster.

Solves https://github.com/dgkf/R/issues/15