### PR TITLE
feat(parser): Support "_" to separate digits

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,6 @@
 # dev
 
+* Digits can now be separated by an underscore to improve readability.
 * Rename `Numeric` variant of `Vector` enum to `Double`
 * Added German (`ger`) localization.
 * Added assertions on function parameters (#74)

--- a/src/grammar/grammar.pest
+++ b/src/grammar/grammar.pest
@@ -41,7 +41,7 @@
         hl_sym = { hl_symbol_backticked | symbol_ident }
         hl_symbol_backticked = ${ "`" ~ (!"`" ~ ANY)* ~ ( "`" | eoi ) }
         hl_str = ${ "\"" ~ double_quoted_string ~ ( "\"" | eoi ) | "'" ~ single_quoted_string ~ ( "'" | eoi ) }
-        hl_num = { number ~ "L"? }
+        hl_num = { number ~ ("L" | "_")? }
         hl_infix = { infix }
         hl_open = { "(" }
         hl_brackets = { hl_open | ")" | "[" | "]" | "{" | "}" }
@@ -170,11 +170,11 @@
 // atomic value types
 
     number = @{ number_leading | number_trailing }
-        number_leading = { ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT*)? }
-        number_trailing = { "." ~ ASCII_DIGIT+ }
+        number_leading = { ("0" | ASCII_NONZERO_DIGIT ~ ("_"? ~ ASCII_DIGIT)*) ~ ("." ~ (ASCII_DIGIT ~ ("_"? ~ ASCII_DIGIT)*))? }
+        number_trailing = { "." ~ (ASCII_DIGIT+ ~ ("_"? ~ ASCII_DIGIT)*) }
 
     integer_expr = _{ integer ~ "L" }
-        integer = @{( ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* | "0" ) }
+        integer = @{( ASCII_NONZERO_DIGIT ~ (("_")? ~ ASCII_DIGIT)* | "0" ) }
 
     string_expr = _{ "\"" ~ double_quoted_string ~ "\"" | "'" ~ single_quoted_string ~ "'" }
         single_quoted_string = @{ single_quoted_string_char* }

--- a/src/grammar/grammar.pest
+++ b/src/grammar/grammar.pest
@@ -171,10 +171,10 @@
 
     number = @{ number_leading | number_trailing }
         number_leading = { ("0" | ASCII_NONZERO_DIGIT ~ ("_"? ~ ASCII_DIGIT)*) ~ ("." ~ (ASCII_DIGIT ~ ("_"? ~ ASCII_DIGIT)*))? }
-        number_trailing = { "." ~ (ASCII_DIGIT+ ~ ("_"? ~ ASCII_DIGIT)*) }
+        number_trailing = { "." ~ (ASCII_DIGIT ~ ("_"? ~ ASCII_DIGIT)*) }
 
     integer_expr = _{ integer ~ "L" }
-        integer = @{( ASCII_NONZERO_DIGIT ~ (("_")? ~ ASCII_DIGIT)* | "0" ) }
+        integer = @{( ASCII_NONZERO_DIGIT ~ ("_"? ~ ASCII_DIGIT)* | "0" ) }
 
     string_expr = _{ "\"" ~ double_quoted_string ~ "\"" | "'" ~ single_quoted_string ~ "'" }
         single_quoted_string = @{ single_quoted_string_char* }

--- a/src/object/ast.rs
+++ b/src/object/ast.rs
@@ -117,9 +117,6 @@ impl fmt::Display for ExprList {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct RExprListItem(Option<String>, Expr);
-
 impl IntoIterator for ExprList {
     type Item = (Option<String>, Expr);
     type IntoIter = <Zip<IntoIter<Option<String>>, IntoIter<Expr>> as IntoIterator>::IntoIter;

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -116,10 +116,16 @@ where
 
         // atomic values
         en::Rule::number => Ok(Expr::Number(
-            pair.as_str().parse::<f64>().map_or(internal_err!(), Ok)?,
+            pair.as_str()
+                .replace('_', "")
+                .parse::<f64>()
+                .map_or(internal_err!(), Ok)?,
         )),
         en::Rule::integer => Ok(Expr::Integer(
-            pair.as_str().parse::<i32>().map_or(internal_err!(), Ok)?,
+            pair.as_str()
+                .replace('_', "")
+                .parse::<i32>()
+                .map_or(internal_err!(), Ok)?,
         )),
         en::Rule::single_quoted_string => Ok(Expr::String(String::from(pair.as_str()))),
         en::Rule::double_quoted_string => Ok(Expr::String(String::from(pair.as_str()))),
@@ -520,6 +526,36 @@ mod test {
         assert_eq! {
             r! {{"c (1)"}},
             r! {{"c(1)"}}
+        }
+    }
+
+    #[test]
+    fn separation_integer() {
+        assert_eq! {
+            r! {{"1_200_000L"}},
+            r! {{"1200000L"}}
+        }
+    }
+
+    #[test]
+    fn separation_double_trailing() {
+        assert_eq! {
+            r! {{".000_123"}},
+            r! {{".000123"}}
+        }
+    }
+    #[test]
+    fn separation_double_leading() {
+        assert_eq! {
+            r! {{"1_2.0_1"}},
+            r! {{"1_2.01"}}
+        }
+    }
+    #[test]
+    fn separation_double_leading_zero() {
+        assert_eq! {
+            r! {{"0.000_123"}},
+            r! {{"0.000123"}}
         }
     }
 }


### PR DESCRIPTION
This allows for better readability, especially of large numbers.

Solves #97