### PR TITLE
Suggestion: Changes to print(ing in the repl)

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Rename `Numeric` variant of `Vector` enum to `Double`
 * Added German (`ger`) localization.
 * Added assertions on function parameters (#74)
+*
 
 # 0.3.3 "Beautiful You"
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -4,7 +4,10 @@
 * Rename `Numeric` variant of `Vector` enum to `Double`
 * Added German (`ger`) localization.
 * Added assertions on function parameters (#74)
-*
+* Removed the `Return` variant of `Signal` that allowed to disable visibility
+  of objects.
+* Improved the behavior of `print()` when used in the repl and it now returns
+  `NULL`
 
 # 0.3.3 "Beautiful You"
 

--- a/src/callable/keywords.rs
+++ b/src/callable/keywords.rs
@@ -25,7 +25,7 @@ impl Callable for KeywordReturn {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut args = args.values.into_iter();
         let value = stack.eval(args.next().unwrap())?;
-        Return(value, true).into()
+        value.into()
     }
 }
 
@@ -110,7 +110,6 @@ impl Callable for KeywordFor {
             match eval_result {
                 Err(Condition(Break)) => break,
                 Err(Condition(Continue)) => continue,
-                Err(Return(..)) => return eval_result,
                 Err(Error(_)) => return eval_result,
                 _ => (),
             }
@@ -158,7 +157,6 @@ impl Callable for KeywordWhile {
             match eval_result {
                 Err(Condition(Break)) => break,
                 Err(Condition(Continue)) => continue,
-                Err(Return(..)) => return eval_result,
                 Err(Error(_)) => return eval_result,
                 _ => (),
             }
@@ -196,7 +194,6 @@ impl Callable for KeywordRepeat {
             match eval_result {
                 Err(Signal::Condition(Cond::Break)) => break,
                 Err(Signal::Condition(Cond::Continue)) => continue,
-                Err(Signal::Return(..)) => return eval_result,
                 Err(Signal::Error(_)) => return eval_result,
                 _ => (),
             }

--- a/src/callable/primitive/print.rs
+++ b/src/callable/primitive/print.rs
@@ -23,10 +23,7 @@ impl Callable for PrimitivePrint {
     fn call_matched(&self, args: List, _ellipsis: List, stack: &mut CallStack) -> EvalResult {
         let mut args = Obj::List(args);
         let x = args.try_get_named("x")?.force(stack)?;
-        match x {
-            Obj::Null => (),
-            _ => println!("{x}"),
-        };
+        println!("{x}");
         Obj::Null.into()
     }
 }

--- a/src/callable/primitive/print.rs
+++ b/src/callable/primitive/print.rs
@@ -23,7 +23,23 @@ impl Callable for PrimitivePrint {
     fn call_matched(&self, args: List, _ellipsis: List, stack: &mut CallStack) -> EvalResult {
         let mut args = Obj::List(args);
         let x = args.try_get_named("x")?.force(stack)?;
-        println!("{x}");
-        Ok(x)
+        match x {
+            Obj::Null => (),
+            _ => println!("{x}"),
+        };
+        Obj::Null.into()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    // test that print returns Null
+    use crate::lang::EvalResult;
+    use crate::object::Obj;
+    use crate::r;
+    #[test]
+    fn test_print() {
+        assert_eq!(r!(print(10)), EvalResult::Ok(Obj::Null))
+    }
+    // TODO: Tests that check for output to stdout
 }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -34,6 +34,12 @@ impl From<Cond> for EvalResult {
         Into::<Signal>::into(val).into()
     }
 }
+impl From<Obj> for EvalResult {
+    #[inline]
+    fn from(val: Obj) -> Self {
+        Ok(val)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Signal {

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -45,16 +45,13 @@ impl From<Obj> for EvalResult {
 pub enum Signal {
     Condition(Cond),
     Error(Error),
-    Return(Obj, bool), // (value, visibility)
-    Tail(Expr, bool),  // (value expr, visibility)
-    Thunk,             // used when evaluating null opts like comments
+    Tail(Expr, bool), // (value expr, visibility)
+    Thunk,            // used when evaluating null opts like comments
 }
 
 impl Display for Signal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Signal::Return(obj, true) => writeln!(f, "{obj}"),
-            Signal::Return(_, false) => Ok(()),
             Signal::Tail(..) => writeln!(f, "Whoops, a tail is loose!"),
             Signal::Condition(_) => writeln!(f, "Signal used at top level"),
             Signal::Error(e) => writeln!(f, "{e}"),
@@ -64,10 +61,6 @@ impl Display for Signal {
 }
 
 impl Obj {
-    pub fn with_visibility(self, visibility: bool) -> EvalResult {
-        Signal::Return(self, visibility).into()
-    }
-
     pub fn force(self, stack: &mut CallStack) -> EvalResult {
         match self {
             // special case for symbols, which are treated as argument promises

--- a/src/repl/core.rs
+++ b/src/repl/core.rs
@@ -51,11 +51,6 @@ pub fn repl(session: Session) -> Result<(), Signal> {
 
                         match stack.eval_and_finalize(expr) {
                             Err(Signal::Condition(Cond::Terminate)) => break,
-                            Err(Signal::Return(value, true)) => match value {
-                                Obj::Null => (),
-                                _ => print!("{value}"),
-                            },
-                            Err(Signal::Return(_value, false)) => (),
                             Err(e) => {
                                 print!("{e}");
                                 print!("backtrace:\n{stack}");

--- a/src/repl/core.rs
+++ b/src/repl/core.rs
@@ -5,7 +5,7 @@ use super::prompt::RPrompt;
 use super::release::*;
 use crate::context::Context;
 use crate::lang::{CallStack, Cond, EvalResult, Signal};
-use crate::object::Environment;
+use crate::object::{Environment, Obj};
 use crate::parser::{Localization, LocalizedParser};
 use crate::session::Session;
 
@@ -51,15 +51,19 @@ pub fn repl(session: Session) -> Result<(), Signal> {
 
                         match stack.eval_and_finalize(expr) {
                             Err(Signal::Condition(Cond::Terminate)) => break,
-                            Err(Signal::Return(value, true)) => {
-                                print!("{value}")
-                            }
+                            Err(Signal::Return(value, true)) => match value {
+                                Obj::Null => (),
+                                _ => print!("{value}"),
+                            },
                             Err(Signal::Return(_value, false)) => (),
                             Err(e) => {
                                 print!("{e}");
                                 print!("backtrace:\n{stack}");
                             }
-                            Ok(val) => println!("{val}"),
+                            Ok(val) => match val {
+                                Obj::Null => (),
+                                _ => println!("{val}"),
+                            },
                         }
                     }
                     Err(e) => eprint!("{e}"),


### PR DESCRIPTION
This is only a very minor detail but I personally think this feels a bit cleaner. 

The changes are: 

* `print()` now returns `NULL`. 
* return values `NULL` are not printed automatically in the repl
* The `Return` variant of the `Signal` enum was removed

The behavior in the repl is now: 

```r
# calling print on NULL explicitly will still do what one expects
> print(NULL)
NULL
# no implicit printing of NULL
> NULL
# calling print explicitly on non-NULL objects prints only once
# because NULL is returned (earlier this would have printed twice)
> print(1:10)
 [1]  1  2  3  4  5  6  7  8  9 10
 # automatic printing also prints once
> 1:10
 [1]  1  2  3  4  5  6  7  8  9 10
>
```

I know this deviates from R, which (usually) returns the value itself when calling print but I think this is not such a bad decision as print is a function called for its side effects and should therefore also not necessarily return anything. 