### PR TITLE
fix: Addressing hanging tail calls short-circuiting binary ops

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,9 +1,22 @@
 # dev
 
-* Digits can now be separated by an underscore to improve readability.
-* Rename `Numeric` variant of `Vector` enum to `Double`
+## Changes
+
 * Added German (`ger`) localization.
+
+* Digits can now be separated by an underscore to improve readability.
+
 * Added assertions on function parameters (#74)
+
+## Internals
+
+* Rename `Numeric` variant of `Vector` enum to `Double`
+
+## Notable Bugs Addressed
+
+* Fix accidental tail calls escaping binary operator evaluation (#115 @dgkf)
+
+* Fix history file not being created if one doesn't already exist (@dgkf)
 
 # 0.3.3 "Beautiful You"
 

--- a/src/context/core.rs
+++ b/src/context/core.rs
@@ -50,7 +50,10 @@ pub trait Context: std::fmt::Debug + std::fmt::Display {
 
     #[inline]
     fn eval_binary(&mut self, exprs: (Expr, Expr)) -> Result<(Obj, Obj), Signal> {
-        Ok((self.eval(exprs.0)?, self.eval(exprs.1)?))
+        Ok((
+            self.eval_and_finalize(exprs.0)?,
+            self.eval_and_finalize(exprs.1)?,
+        ))
     }
 
     fn eval_list_lazy(&mut self, l: ExprList) -> EvalResult {

--- a/src/repl/core.rs
+++ b/src/repl/core.rs
@@ -16,13 +16,14 @@ pub fn repl(session: Session) -> Result<(), Signal> {
         ..Default::default()
     });
 
-    let history = if std::path::PathBuf::from(&session.history).exists() {
-        println!("Restoring session history...");
-        FileBackedHistory::with_file(1000, session.history.clone().into())
-            .expect("Error configuring history with file")
-    } else {
-        FileBackedHistory::new(1000)
-    };
+    let history = session
+        .history
+        .clone()
+        .map_or(FileBackedHistory::new(1000), |file| {
+            println!("Restoring session history...");
+            FileBackedHistory::with_file(1000, file.into())
+                .expect("Error configuring history with file")
+        });
 
     let mut line_editor = Reedline::create()
         .with_validator(Box::new(session.clone()))

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,12 +6,12 @@ pub struct Session {
     pub locale: Localization,
     pub warranty: bool,
     pub experiments: Vec<Experiment>,
-    pub history: String,
+    pub history: Option<String>,
 }
 
 impl Session {
     pub fn with_history_file(mut self, file: String) -> Session {
-        self.history = file;
+        self.history = Some(file);
         self
     }
 }
@@ -22,7 +22,7 @@ impl From<Cli> for Session {
             locale: value.locale,
             warranty: value.warranty,
             experiments: value.experiments,
-            history: "".to_string(),
+            history: None,
         }
     }
 }


### PR DESCRIPTION
Closes #115

Binary operator expressions are now "finalized", meaning that tail calls get coerced into returns instead of awaiting lazy evaluation. 

This does mean that when the binary operator expression is the "tail" it will no longer apply tail call optimization. This is a preferred behavior for the immediate future and may prove to be the preferred style long term.

```r
$ r --experiments=tail-calls
> f <- fn(n) if (n > 0) 1 + f(n - 1) else n
> f(100)
# [1] 100
> f(1000)
# fatal runtime error: stack overflow
```