### PR TITLE
Adding callback output mode, allowing printing in wasm

### DIFF
--- a/demo/assets/prompt/src.js
+++ b/demo/assets/prompt/src.js
@@ -159,18 +159,19 @@ class Repl {
 
     this.output.log.push(code);
 
-    var output = this.#elem_output;
+    var history_elem = this.#elem_output;
     if (this.output.mode === "history") {
-      output = this.#output_push("input", this.#markup_highlight(code));
+      history_elem = this.#output_push("input", this.#markup_highlight(code));
       this.clear();
     }
   
     // get result and print to output
     try { 
-      let result = this.eval(code);
+      let output_elem = this.#output_push("output", "", history_elem, false);
+      let result = this.eval(code, (x) => output_elem.innerText += x);
       if (this.output.mode === "single") this.#elem_output.innerHTML = "";
-      let node = this.#output_push("output", result, output, false);
-      node.scrollIntoView();
+      output_elem.innerText += result;
+      output_elem.scrollIntoView();
     } catch (error) {
       console.log(error);
       let node = this.#markup_unexpected_error();

--- a/demo/index.html
+++ b/demo/index.html
@@ -131,6 +131,7 @@ sum
 `;
       }
 
+      window.r_args = args;
       window.r = r;
       const r_env = {
         "args": args,

--- a/src/callable/primitive/print.rs
+++ b/src/callable/primitive/print.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use r_derive::*;
+use std::io::Write;
 
 use crate::callable::core::*;
 use crate::lang::*;
@@ -23,7 +24,7 @@ impl Callable for PrimitivePrint {
     fn call_matched(&self, args: List, _ellipsis: List, stack: &mut CallStack) -> EvalResult {
         let mut args = Obj::List(args);
         let x = args.try_get_named("x")?.force(stack)?;
-        println!("{x}");
+        writeln!(stack.session.output, "{x}").ok();
         Ok(x)
     }
 }

--- a/src/object/environment.rs
+++ b/src/object/environment.rs
@@ -40,8 +40,6 @@ impl Environment {
         for (key, value) in l.values.borrow().iter() {
             if let Some(name) = key {
                 self.values.borrow_mut().insert(name.clone(), value.clone());
-            } else {
-                println!("Dont' know what to do with value...")
             }
         }
     }

--- a/src/repl/highlight.rs
+++ b/src/repl/highlight.rs
@@ -3,30 +3,11 @@ use reedline::Highlighter;
 use reedline::StyledText;
 
 use crate::parser::*;
-use crate::session::Session;
 
 impl Highlighter for Localization {
     fn highlight(&self, line: &str, _pos: usize) -> StyledText {
         let mut styled_text = StyledText::new();
         match self.parse_highlight(line) {
-            Ok(pairs) => {
-                for (text, style) in pairs.into_iter() {
-                    styled_text.push((style.into(), text));
-                }
-                styled_text
-            }
-            Err(_) => {
-                styled_text.push((Style::new(), line.to_string()));
-                styled_text
-            }
-        }
-    }
-}
-
-impl Highlighter for Session {
-    fn highlight(&self, line: &str, _pos: usize) -> StyledText {
-        let mut styled_text = StyledText::new();
-        match self.locale.parse_highlight_with(line, self) {
             Ok(pairs) => {
                 for (text, style) in pairs.into_iter() {
                     styled_text.push((style.into(), text));

--- a/src/repl/validator.rs
+++ b/src/repl/validator.rs
@@ -1,19 +1,9 @@
-use crate::{parser::*, session::Session};
+use crate::parser::*;
 use reedline::{ValidationResult, Validator};
 
 impl Validator for Localization {
     fn validate(&self, line: &str) -> ValidationResult {
         let res = self.parse_input(line);
-        match res {
-            Ok(_) => ValidationResult::Complete,
-            Err(_) => ValidationResult::Incomplete,
-        }
-    }
-}
-
-impl Validator for Session {
-    fn validate(&self, line: &str) -> ValidationResult {
-        let res = self.locale.parse_input_with(line, self);
         match res {
             Ok(_) => ValidationResult::Complete,
             Err(_) => ValidationResult::Incomplete,

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,7 @@
+use std::rc::Rc;
+
 use crate::cli::{Cli, Experiment};
-use crate::parser::{Localization, LocalizedParser};
+use crate::parser::Localization;
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Session {
@@ -7,11 +9,72 @@ pub struct Session {
     pub warranty: bool,
     pub experiments: Vec<Experiment>,
     pub history: Option<String>,
+    pub output: SessionOutput,
+}
+
+pub enum SessionOutput {
+    Stdout(std::io::Stdout),
+    Callback(Rc<dyn Fn(String)>),
+}
+
+impl std::fmt::Debug for SessionOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionOutput::Stdout(s) => s.fmt(f),
+            SessionOutput::Callback(_) => write!(f, "SessionOutput::Callback"),
+        }
+    }
+}
+
+impl Default for SessionOutput {
+    fn default() -> Self {
+        SessionOutput::Stdout(std::io::stdout())
+    }
+}
+
+impl Clone for SessionOutput {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Stdout(_) => Self::Stdout(std::io::stdout()),
+            Self::Callback(f) => Self::Callback(f.clone()),
+        }
+    }
+}
+
+impl PartialEq for SessionOutput {
+    fn eq(&self, other: &Self) -> bool {
+        matches!((self, other), (Self::Stdout(_), Self::Stdout(_)))
+    }
+}
+
+impl std::io::Write for SessionOutput {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Stdout(s) => s.write(buf),
+            Self::Callback(f) => {
+                let len = buf.len();
+                f(std::str::from_utf8(buf).unwrap_or_default().to_string());
+                Ok(len)
+            }
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Stdout(s) => s.flush(),
+            Self::Callback(_) => Ok(()),
+        }
+    }
 }
 
 impl Session {
     pub fn with_history_file(mut self, file: String) -> Session {
         self.history = Some(file);
+        self
+    }
+
+    pub fn with_output(mut self, output: SessionOutput) -> Session {
+        self.output = output;
         self
     }
 }
@@ -23,28 +86,7 @@ impl From<Cli> for Session {
             warranty: value.warranty,
             experiments: value.experiments,
             history: None,
+            output: SessionOutput::default(),
         }
-    }
-}
-
-impl LocalizedParser for Session {
-    fn parse_input(&self, input: &str) -> crate::parser::ParseResult {
-        self.locale.parse_input_with(input, self)
-    }
-
-    fn parse_highlight(&self, input: &str) -> crate::parser::HighlightResult {
-        self.locale.parse_highlight_with(input, self)
-    }
-
-    fn parse_input_with(&self, input: &str, session: &Session) -> crate::parser::ParseResult {
-        self.locale.parse_input_with(input, session)
-    }
-
-    fn parse_highlight_with(
-        &self,
-        input: &str,
-        session: &Session,
-    ) -> crate::parser::HighlightResult {
-        self.locale.parse_highlight_with(input, session)
     }
 }


### PR DESCRIPTION
Adds `Session.output` field, defining how output should be displayed. Must implement `std::fmt::Write`.

For now it only has two variants - either stdout or a callback. The callback allows for a JavaScript function to be passed as a callback to append output as it is printed. 