### PR TITLE
Fix: promise evaluation

### DIFF
--- a/src/callable/builtins.rs
+++ b/src/callable/builtins.rs
@@ -52,7 +52,6 @@ lazy_static! {
             ("quote", Box::new(PrimitiveQuote) as Box<dyn Builtin>),
             ("rnorm", Box::new(PrimitiveRnorm) as Box<dyn Builtin>),
             ("runif", Box::new(PrimitiveRunif) as Box<dyn Builtin>),
-            ("substitute", Box::new(PrimitiveSubstitute) as Box<dyn Builtin>),
             ("sum", Box::new(PrimitiveSum) as Box<dyn Builtin>),
             // builtins end
         ])

--- a/src/callable/builtins.rs
+++ b/src/callable/builtins.rs
@@ -52,6 +52,7 @@ lazy_static! {
             ("quote", Box::new(PrimitiveQuote) as Box<dyn Builtin>),
             ("rnorm", Box::new(PrimitiveRnorm) as Box<dyn Builtin>),
             ("runif", Box::new(PrimitiveRunif) as Box<dyn Builtin>),
+            ("substitute", Box::new(PrimitiveSubstitute) as Box<dyn Builtin>),
             ("sum", Box::new(PrimitiveSum) as Box<dyn Builtin>),
             // builtins end
         ])

--- a/src/callable/core.rs
+++ b/src/callable/core.rs
@@ -93,7 +93,7 @@ pub trait Callable {
         for (param, default) in formals.into_iter() {
             matched_args.values.borrow_mut().push((
                 param,
-                Obj::Closure(default, stack.last_frame().env().clone()),
+                Obj::Promise(default, stack.last_frame().env().clone()),
             ));
         }
 

--- a/src/callable/primitive/environment.rs
+++ b/src/callable/primitive/environment.rs
@@ -20,7 +20,7 @@ impl Callable for PrimitiveEnvironment {
 
         // default when `fun` is missing or not found
         let fun = vals.try_get_named("fun");
-        if let Ok(Obj::Closure(Expr::Missing, _)) | Err(Signal::Error(Error::ArgumentMissing(_))) =
+        if let Ok(Obj::Promise(Expr::Missing, _)) | Err(Signal::Error(Error::ArgumentMissing(_))) =
             fun
         {
             return Ok(Obj::Environment(stack.env().clone()));
@@ -28,7 +28,7 @@ impl Callable for PrimitiveEnvironment {
 
         // otherwise we can evaluate value and return result's environment
         match fun?.force(stack)? {
-            Obj::Closure(_, e) => Ok(Obj::Environment(e.clone())),
+            Obj::Promise(_, e) => Ok(Obj::Environment(e.clone())),
             Obj::Function(_, _, e) => Ok(Obj::Environment(e.clone())),
             Obj::Environment(e) => Ok(Obj::Environment(e.clone())),
             _ => Error::ArgumentInvalid(String::from("fun")).into(),

--- a/src/callable/primitive/names.rs
+++ b/src/callable/primitive/names.rs
@@ -18,7 +18,7 @@ impl Callable for PrimitiveNames {
         use Obj::*;
         match x {
             Null => Ok(Null),
-            Closure(_, _) => Ok(Null),
+            Promise(_, _) => Ok(Null),
             Vector(_) => Ok(Null), // named vectors currently not supported...
             Expr(_) => Ok(Null),   // handle arg lists?
             Function(_, _, _) => Ok(Null), // return formals?

--- a/src/callable/primitive/parent.rs
+++ b/src/callable/primitive/parent.rs
@@ -19,7 +19,7 @@ impl Callable for PrimitiveParent {
 
         // default when `x` is missing or not found
         let x = vals.try_get_named("x");
-        if let Ok(Obj::Closure(Expr::Missing, _)) | Err(_) = x {
+        if let Ok(Obj::Promise(Expr::Missing, _)) | Err(_) = x {
             return Ok(stack
                 .env()
                 .parent

--- a/src/context/core.rs
+++ b/src/context/core.rs
@@ -76,11 +76,11 @@ pub trait Context: std::fmt::Debug + std::fmt::Display {
                     }
                     // Avoid creating a new closure just to point to another, just reuse it
                     (k, Expr::Symbol(s)) => match self.env().get(s.clone()) {
-                        Ok(c @ Obj::Closure(..)) => Ok(vec![(k, c)].into_iter()),
-                        _ => Ok(vec![(k, Obj::Closure(Expr::Symbol(s), self.env()))].into_iter()),
+                        Ok(c @ Obj::Promise(..)) => Ok(vec![(k, c)].into_iter()),
+                        _ => Ok(vec![(k, Obj::Promise(Expr::Symbol(s), self.env()))].into_iter()),
                     },
                     (k, c @ Expr::Call(..)) => {
-                        let elem = vec![(k, Obj::Closure(c, self.env()))];
+                        let elem = vec![(k, Obj::Promise(c, self.env()))];
                         Ok(elem.into_iter())
                     }
                     (k, v) => {

--- a/src/object/core.rs
+++ b/src/object/core.rs
@@ -16,7 +16,7 @@ pub enum Obj {
 
     // Metaprogramming structures
     Expr(Expr),
-    Closure(Expr, Rc<Environment>),
+    Promise(Expr, Rc<Environment>),
     Function(ExprList, Expr, Rc<Environment>),
     Environment(Rc<Environment>),
 }
@@ -35,7 +35,7 @@ impl PartialEq for Obj {
                     .all(|((lk, lv), (rk, rv))| lk == rk && lv == rv)
             }
             (Obj::Expr(l), Obj::Expr(r)) => l == r,
-            (Obj::Closure(lc, lenv), Obj::Closure(rc, renv)) => lc == rc && lenv == renv,
+            (Obj::Promise(lc, lenv), Obj::Promise(rc, renv)) => lc == rc && lenv == renv,
             (Obj::Function(largs, lbody, lenv), Obj::Function(rargs, rbody, renv)) => {
                 largs == rargs
                     && lbody == rbody

--- a/src/object/environment.rs
+++ b/src/object/environment.rs
@@ -49,7 +49,7 @@ impl Environment {
         if let Some(value) = self.values.borrow().get(&name) {
             let result = value.clone();
             match result {
-                Obj::Closure(expr, env) => env.clone().eval(expr),
+                Obj::Promise(expr, env) => env.clone().eval(expr),
                 _ => Ok(result),
             }
 


### PR DESCRIPTION
Closes #122

Fix: Saves result of forcing promise back into environment, instead of re-evaluating it every time.

Chore: Renames `Closure` to `Promise`. Maybe eventually there will be a need for both, but for now I think `Promise` is a better indication of what this represents. A `Closure` might be better represented by a function anyways (I think internally R refers to its functions as "closures" anyways since they always capture their environments). 