### PR TITLE
feat: add primitive substitute

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -7,11 +7,16 @@
 * Digits can now be separated by an underscore to improve readability.
 
 * Added assertions on function parameters (#74)
+
 * Assignment is now also possible using the `=` operator (#144 @sebffischer)
+
+* Added new primtiive function, `substitute()` (#125 @dgkf)
 
 ## Internals
 
 * Rename `Numeric` variant of `Vector` enum to `Double`
+
+* Promises now retain their expression even after being evaluated (#125 @dgkf)
 
 ## Notable Bugs Addressed
 

--- a/src/callable/builtins.rs
+++ b/src/callable/builtins.rs
@@ -52,6 +52,7 @@ lazy_static! {
             ("quote", Box::new(PrimitiveQuote) as Box<dyn Builtin>),
             ("rnorm", Box::new(PrimitiveRnorm) as Box<dyn Builtin>),
             ("runif", Box::new(PrimitiveRunif) as Box<dyn Builtin>),
+            ("substitute", Box::new(PrimitiveSubstitute) as Box<dyn Builtin>),
             ("sum", Box::new(PrimitiveSum) as Box<dyn Builtin>),
             // builtins end
         ])

--- a/src/callable/core.rs
+++ b/src/callable/core.rs
@@ -93,7 +93,7 @@ pub trait Callable {
         for (param, default) in formals.into_iter() {
             matched_args.values.borrow_mut().push((
                 param,
-                Obj::Promise(default, stack.last_frame().env().clone()),
+                Obj::Promise(None, default, stack.last_frame().env().clone()),
             ));
         }
 

--- a/src/callable/primitive/environment.rs
+++ b/src/callable/primitive/environment.rs
@@ -20,16 +20,16 @@ impl Callable for PrimitiveEnvironment {
 
         // default when `fun` is missing or not found
         let fun = vals.try_get_named("fun");
-        if let Ok(Obj::Promise(Expr::Missing, _)) | Err(Signal::Error(Error::ArgumentMissing(_))) =
-            fun
+        if let Ok(Obj::Promise(_, Expr::Missing, _))
+        | Err(Signal::Error(Error::ArgumentMissing(_))) = fun
         {
             return Ok(Obj::Environment(stack.env().clone()));
         };
 
         // otherwise we can evaluate value and return result's environment
         match fun?.force(stack)? {
-            Obj::Promise(_, e) => Ok(Obj::Environment(e.clone())),
-            Obj::Function(_, _, e) => Ok(Obj::Environment(e.clone())),
+            Obj::Promise(.., e) => Ok(Obj::Environment(e.clone())),
+            Obj::Function(.., e) => Ok(Obj::Environment(e.clone())),
             Obj::Environment(e) => Ok(Obj::Environment(e.clone())),
             _ => Error::ArgumentInvalid(String::from("fun")).into(),
         }

--- a/src/callable/primitive/mod.rs
+++ b/src/callable/primitive/mod.rs
@@ -24,5 +24,7 @@ mod rnorm;
 pub use rnorm::PrimitiveRnorm;
 mod runif;
 pub use runif::PrimitiveRunif;
+mod substitute;
+pub use substitute::PrimitiveSubstitute;
 mod sum;
 pub use sum::PrimitiveSum;

--- a/src/callable/primitive/names.rs
+++ b/src/callable/primitive/names.rs
@@ -18,10 +18,10 @@ impl Callable for PrimitiveNames {
         use Obj::*;
         match x {
             Null => Ok(Null),
-            Promise(_, _) => Ok(Null),
-            Vector(_) => Ok(Null), // named vectors currently not supported...
-            Expr(_) => Ok(Null),   // handle arg lists?
-            Function(_, _, _) => Ok(Null), // return formals?
+            Promise(..) => Ok(Null),
+            Vector(..) => Ok(Null), // named vectors currently not supported...
+            Expr(..) => Ok(Null),   // handle arg lists?
+            Function(..) => Ok(Null), // return formals?
             List(x) => {
                 Ok(x.values
                     .borrow()

--- a/src/callable/primitive/parent.rs
+++ b/src/callable/primitive/parent.rs
@@ -19,7 +19,7 @@ impl Callable for PrimitiveParent {
 
         // default when `x` is missing or not found
         let x = vals.try_get_named("x");
-        if let Ok(Obj::Promise(Expr::Missing, _)) | Err(_) = x {
+        if let Ok(Obj::Promise(_, Expr::Missing, _)) | Err(_) = x {
             return Ok(stack
                 .env()
                 .parent

--- a/src/callable/primitive/substitute.rs
+++ b/src/callable/primitive/substitute.rs
@@ -1,0 +1,79 @@
+use std::rc::Rc;
+
+use lazy_static::lazy_static;
+use r_derive::*;
+
+use crate::callable::core::*;
+use crate::context::Context;
+use crate::err;
+use crate::internal_err;
+use crate::lang::*;
+use crate::object::*;
+
+lazy_static! {
+    pub static ref FORMALS: ExprList = ExprList::from(vec![
+        (Some("expr".to_string()), Expr::Missing),
+        (
+            Some("envir".to_string()),
+            Expr::Call(
+                Box::new(Expr::Symbol("environment".to_string())),
+                ExprList::new()
+            )
+        )
+    ]);
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[builtin(sym = "substitute")]
+pub struct PrimitiveSubstitute;
+impl Callable for PrimitiveSubstitute {
+    fn formals(&self) -> ExprList {
+        FORMALS.clone()
+    }
+
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        use Expr::*;
+        let (args, _ellipsis) = self.match_arg_exprs(args, stack)?;
+        let mut args = Obj::List(args);
+
+        let Obj::Environment(env) = args.try_get_named("envir")?.force(stack)? else {
+            return internal_err!();
+        };
+
+        let Obj::Promise(expr, _) = args.try_get_named("expr")? else {
+            return internal_err!();
+        };
+
+        fn recurse(exprs: ExprList, env: &Environment) -> ExprList {
+            exprs
+                .into_iter()
+                .map(|(key, expr)| (key, substitute(expr, env)))
+                .collect()
+        }
+
+        fn substitute(expr: Expr, env: &Environment) -> Expr {
+            match expr {
+                Symbol(s) => {
+                    // promises are replaced
+                    match env.values.borrow().get(&s) {
+                        Some(Obj::Promise(expr, ..)) => expr.clone(),
+                        None => todo!(),
+                    }
+                }
+                List(exprs) => List(recurse(exprs, env)),
+                Function(params, body) => {
+                    Function(recurse(params, env), Box::new(substitute(*body, env)))
+                }
+                Call(what, exprs) => Call(Box::new(substitute(*what, env)), recurse(exprs, env)),
+                other => other,
+            }
+        }
+
+        match substitute(expr, env.as_ref()) {
+            e @ (Symbol(_) | List(..) | Function(..) | Call(..) | Primitive(..)) => {
+                Ok(Obj::Expr(e))
+            }
+            other => stack.eval(other),
+        }
+    }
+}

--- a/src/context/core.rs
+++ b/src/context/core.rs
@@ -75,12 +75,15 @@ pub trait Context: std::fmt::Debug + std::fmt::Display {
                         }
                     }
                     // Avoid creating a new closure just to point to another, just reuse it
-                    (k, Expr::Symbol(s)) => match self.env().get(s.clone()) {
-                        Ok(c @ Obj::Promise(..)) => Ok(vec![(k, c)].into_iter()),
-                        _ => Ok(vec![(k, Obj::Promise(Expr::Symbol(s), self.env()))].into_iter()),
-                    },
+                    (k, Expr::Symbol(s)) => {
+                        match self.env().get(s.clone()) {
+                            Ok(c @ Obj::Promise(..)) => Ok(vec![(k, c)].into_iter()),
+                            _ => Ok(vec![(k, Obj::Promise(None, Expr::Symbol(s), self.env()))]
+                                .into_iter()),
+                        }
+                    }
                     (k, c @ Expr::Call(..)) => {
-                        let elem = vec![(k, Obj::Promise(c, self.env()))];
+                        let elem = vec![(k, Obj::Promise(None, c, self.env()))];
                         Ok(elem.into_iter())
                     }
                     (k, v) => {

--- a/src/object/core.rs
+++ b/src/object/core.rs
@@ -16,7 +16,7 @@ pub enum Obj {
 
     // Metaprogramming structures
     Expr(Expr),
-    Promise(Expr, Rc<Environment>),
+    Promise(Option<Box<Obj>>, Expr, Rc<Environment>),
     Function(ExprList, Expr, Rc<Environment>),
     Environment(Rc<Environment>),
 }
@@ -35,7 +35,11 @@ impl PartialEq for Obj {
                     .all(|((lk, lv), (rk, rv))| lk == rk && lv == rv)
             }
             (Obj::Expr(l), Obj::Expr(r)) => l == r,
-            (Obj::Promise(lc, lenv), Obj::Promise(rc, renv)) => lc == rc && lenv == renv,
+            (Obj::Promise(None, lc, lenv), Obj::Promise(None, rc, renv)) => {
+                lc == rc && lenv == renv
+            }
+            (Obj::Promise(Some(a), ..), Obj::Promise(Some(b), ..)) => a == b,
+            (Obj::Promise(..), Obj::Promise(..)) => false,
             (Obj::Function(largs, lbody, lenv), Obj::Function(rargs, rbody, renv)) => {
                 largs == rargs
                     && lbody == rbody

--- a/src/object/environment.rs
+++ b/src/object/environment.rs
@@ -49,7 +49,8 @@ impl Environment {
         if let Some(value) = self.values.borrow().get(&name) {
             let result = value.clone();
             match result {
-                Obj::Promise(expr, env) => env.clone().eval(expr),
+                Obj::Promise(None, expr, env) => env.clone().eval(expr),
+                Obj::Promise(Some(result), ..) => Ok(*result),
                 _ => Ok(result),
             }
 


### PR DESCRIPTION
- Reworks what was `Closure` (this was probably misnamed to begin with) as `Promise` and adopts R's style of promise which retains its originating expression even after being forced. 
- Adds `substitute()`