### PR TITLE
fix: re-enable experiment flags

### DIFF
--- a/r_derive/src/lib.rs
+++ b/r_derive/src/lib.rs
@@ -280,10 +280,10 @@ pub fn derive_localized_parser(input: TokenStream) -> TokenStream {
         extern crate self as __localized_parser_r__;
         use __localized_parser_r__::error::Error;
         use __localized_parser_r__::lang:: Signal;
-        use __localized_parser_r__::session:: Session;
+        use __localized_parser_r__::session:: SessionParserConfig;
         use __localized_parser_r__::parser::*;
         impl LocalizedParser for #what {
-            fn parse_input_with(&self, input: &str, session: &Session) -> ParseResult {
+            fn parse_input_with(&self, input: &str, config: &SessionParserConfig) -> ParseResult {
                 let pairs = <Self as pest::Parser<Rule>>::parse(Rule::repl, input);
 
                 match pairs {
@@ -291,12 +291,12 @@ pub fn derive_localized_parser(input: TokenStream) -> TokenStream {
                     Ok(pairs) if pairs.len() == 0 => Err(Signal::Thunk),
 
                     // for any expressions
-                    Ok(pairs) => parse_expr(session, self, pratt_parser(), pairs),
+                    Ok(pairs) => parse_expr(config, self, pratt_parser(), pairs),
                     Err(e) => Err(Signal::Error(Error::from_parse_error(input, e))),
                 }
             }
 
-            fn parse_highlight_with(&self, input: &str, session: &Session) -> HighlightResult {
+            fn parse_highlight_with(&self, input: &str, config: &SessionParserConfig) -> HighlightResult {
                 let pairs = <Self as pest::Parser<Rule>>::parse(Rule::hl, input);
                 match pairs {
                     Ok(pairs) => Ok(pairs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
     derive(Serialize, Deserialize),
     serde(rename_all(serialize = "kebab-case", deserialize = "kebab-case"))
 )]
-#[derive(Debug, Copy, Clone, PartialEq, clap::ValueEnum, strum::EnumString)]
+#[derive(Debug, Copy, Clone, PartialEq, clap::ValueEnum, strum::EnumString, strum::EnumIter)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Experiment {
     TailCalls,

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -13,7 +13,7 @@ use crate::internal_err;
 use crate::lang::Signal;
 use crate::object::{Expr, ExprList};
 use crate::parser::*;
-use crate::session::Session;
+use crate::session::SessionParserConfig;
 use pest::iterators::{Pair, Pairs};
 use pest::pratt_parser::PrattParser;
 use pest::{Parser, RuleType};
@@ -22,7 +22,7 @@ pub type ParseResult = Result<Expr, Signal>;
 pub type ParseListResult = Result<ExprList, Signal>;
 
 pub fn parse_expr<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pairs: Pairs<R>,
@@ -32,7 +32,7 @@ where
     R: RuleType + Into<en::Rule>,
 {
     pratt
-        .map_primary(|pair| parse_primary(session, parser, pratt, pair))
+        .map_primary(|pair| parse_primary(config, parser, pratt, pair))
         .map_infix(|lhs, op, rhs| {
             // infix operator with two unnamed arguments
             let args = vec![(None, lhs?), (None, rhs?)].into();
@@ -69,7 +69,7 @@ where
 }
 
 fn parse_primary<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -80,22 +80,22 @@ where
 {
     match pair.as_rule().into() {
         // prefix and postfix notation
-        en::Rule::postfixed => parse_postfixed(session, parser, pratt, pair),
-        en::Rule::prefixed => parse_prefixed(session, parser, pratt, pair),
+        en::Rule::postfixed => parse_postfixed(config, parser, pratt, pair),
+        en::Rule::prefixed => parse_prefixed(config, parser, pratt, pair),
 
         // bracketed expression block
-        en::Rule::expr => parse_expr(session, parser, pratt, pair.into_inner()),
-        en::Rule::block_exprs => parse_block(session, parser, pratt, pair),
+        en::Rule::expr => parse_expr(config, parser, pratt, pair.into_inner()),
+        en::Rule::block_exprs => parse_block(config, parser, pratt, pair),
 
         // keyworded composite expressions
-        en::Rule::kw_function => parse_function(session, parser, pratt, pair),
-        en::Rule::kw_while => parse_while(session, parser, pratt, pair),
-        en::Rule::kw_for => parse_for(session, parser, pratt, pair),
-        en::Rule::kw_if_else => parse_if_else(session, parser, pratt, pair),
-        en::Rule::kw_repeat => parse_repeat(session, parser, pratt, pair),
+        en::Rule::kw_function => parse_function(config, parser, pratt, pair),
+        en::Rule::kw_while => parse_while(config, parser, pratt, pair),
+        en::Rule::kw_for => parse_for(config, parser, pratt, pair),
+        en::Rule::kw_if_else => parse_if_else(config, parser, pratt, pair),
+        en::Rule::kw_repeat => parse_repeat(config, parser, pratt, pair),
         en::Rule::kw_break => Ok(Expr::Break),
         en::Rule::kw_continue => Ok(Expr::Continue),
-        en::Rule::kw_return => parse_return(session, parser, pratt, pair),
+        en::Rule::kw_return => parse_return(config, parser, pratt, pair),
 
         // reserved values
         en::Rule::val_true => Ok(Expr::Bool(true)),
@@ -107,7 +107,7 @@ where
         // reserved symbols
         en::Rule::ellipsis => Ok(Expr::Ellipsis(None)),
         en::Rule::more => {
-            if session.experiments.contains(&Experiment::RestArgs) {
+            if config.experiments.contains(&Experiment::RestArgs) {
                 Ok(Expr::More)
             } else {
                 Err(Error::FeatureDisabledRestArgs.into())
@@ -131,12 +131,12 @@ where
         en::Rule::double_quoted_string => Ok(Expr::String(String::from(pair.as_str()))),
 
         // structured values
-        en::Rule::vec => parse_vec(session, parser, pratt, pair),
-        en::Rule::list => parse_list(session, parser, pratt, pair),
+        en::Rule::vec => parse_vec(config, parser, pratt, pair),
+        en::Rule::list => parse_list(config, parser, pratt, pair),
 
         // calls and symbols
-        en::Rule::call => parse_call(session, parser, pratt, pair),
-        en::Rule::symbol_ident => parse_symbol(session, parser, pratt, pair),
+        en::Rule::call => parse_call(config, parser, pratt, pair),
+        en::Rule::symbol_ident => parse_symbol(config, parser, pratt, pair),
         en::Rule::symbol_backticked => Ok(Expr::Symbol(String::from(pair.as_str()))),
 
         // otherwise fail
@@ -148,7 +148,7 @@ where
 }
 
 fn parse_block<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -160,7 +160,7 @@ where
     // extract each inline expression, and treat as unnamed list
     let exprs: ExprList = pair
         .into_inner()
-        .map(|i| parse_expr(session, parser, pratt, i.into_inner()))
+        .map(|i| parse_expr(config, parser, pratt, i.into_inner()))
         .collect::<Result<_, _>>()?;
 
     // build call from symbol and list
@@ -168,7 +168,7 @@ where
 }
 
 fn parse_named<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -179,11 +179,11 @@ where
 {
     let mut inner = pair.into_inner();
     let name = String::from(inner.next().unwrap().as_str());
-    Ok((Some(name), parse_expr(session, parser, pratt, inner)?))
+    Ok((Some(name), parse_expr(config, parser, pratt, inner)?))
 }
 
 fn parse_pairlist<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -195,9 +195,9 @@ where
     let exprs: ExprList = pair
         .into_inner()
         .map(|i| match i.as_rule().into() {
-            en::Rule::named => parse_named(session, parser, pratt, i),
+            en::Rule::named => parse_named(config, parser, pratt, i),
             en::Rule::ellipsis => Ok((None, Expr::Ellipsis(None))),
-            _ => Ok((None, parse_primary(session, parser, pratt, i)?)),
+            _ => Ok((None, parse_primary(config, parser, pratt, i)?)),
         })
         .collect::<Result<_, _>>()?;
 
@@ -205,7 +205,7 @@ where
 }
 
 fn parse_call<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -217,7 +217,7 @@ where
     let mut inner = pair.into_inner();
     let name = inner.next().map_or(internal_err!(), |i| Ok(i.as_str()))?;
     let pairs = parse_pairlist(
-        session,
+        config,
         parser,
         pratt,
         inner.next().map_or(internal_err!(), Ok)?,
@@ -230,7 +230,7 @@ where
 }
 
 fn parse_function<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -241,18 +241,18 @@ where
 {
     let mut inner = pair.into_inner();
     let params = parse_pairlist(
-        session,
+        config,
         parser,
         pratt,
         inner.next().map_or(internal_err!(), Ok)?,
     )?
     .as_formals();
-    let body = parse_expr(session, parser, pratt, inner)?;
+    let body = parse_expr(config, parser, pratt, inner)?;
     Ok(Expr::Function(params, Box::new(body)))
 }
 
 fn parse_if_else<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -264,13 +264,13 @@ where
     let mut inner = pair.into_inner();
 
     let inner_cond = inner.next().map_or(internal_err!(), Ok)?.into_inner();
-    let cond = parse_expr(session, parser, pratt, inner_cond)?;
+    let cond = parse_expr(config, parser, pratt, inner_cond)?;
 
     let inner_true = inner.next().map_or(internal_err!(), Ok)?.into_inner();
-    let true_expr = parse_expr(session, parser, pratt, inner_true)?;
+    let true_expr = parse_expr(config, parser, pratt, inner_true)?;
 
     let false_expr = if let Some(false_block) = inner.next() {
-        parse_expr(session, parser, pratt, false_block.into_inner())?
+        parse_expr(config, parser, pratt, false_block.into_inner())?
     } else {
         Expr::Null
     };
@@ -280,7 +280,7 @@ where
 }
 
 fn parse_return<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -291,13 +291,13 @@ where
 {
     let mut inner = pair.into_inner();
     let inner_expr = inner.next().map_or(internal_err!(), Ok)?.into_inner();
-    let expr = parse_expr(session, parser, pratt, inner_expr)?;
+    let expr = parse_expr(config, parser, pratt, inner_expr)?;
     let args = ExprList::from(vec![expr]);
     Ok(Expr::new_primitive_call(KeywordReturn, args))
 }
 
 fn parse_symbol<P, R>(
-    _session: &Session,
+    _config: &SessionParserConfig,
     _parser: &P,
     _pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -310,7 +310,7 @@ where
 }
 
 fn parse_for<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -322,22 +322,22 @@ where
     let mut inner = pair.into_inner();
 
     let inner_sym = inner.next().map_or(internal_err!(), Ok)?;
-    let Expr::Symbol(var) = parse_symbol(session, parser, pratt, inner_sym)? else {
+    let Expr::Symbol(var) = parse_symbol(config, parser, pratt, inner_sym)? else {
         return internal_err!();
     };
 
     let inner_iter = inner.next().map_or(internal_err!(), Ok)?.into_inner();
-    let iter = parse_expr(session, parser, pratt, inner_iter)?;
+    let iter = parse_expr(config, parser, pratt, inner_iter)?;
 
     let inner_body = inner.next().map_or(internal_err!(), Ok)?.into_inner();
-    let body = parse_expr(session, parser, pratt, inner_body)?;
+    let body = parse_expr(config, parser, pratt, inner_body)?;
 
     let args = ExprList::from(vec![(Some(var), iter), (None, body)]);
     Ok(Expr::new_primitive_call(KeywordFor, args))
 }
 
 fn parse_while<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -348,15 +348,15 @@ where
 {
     let mut inner = pair.into_inner();
     let inner_cond = inner.next().map_or(internal_err!(), Ok)?.into_inner();
-    let cond = parse_expr(session, parser, pratt, inner_cond)?;
+    let cond = parse_expr(config, parser, pratt, inner_cond)?;
     let inner_body = inner.next().map_or(internal_err!(), Ok)?.into_inner();
-    let body = parse_expr(session, parser, pratt, inner_body)?;
+    let body = parse_expr(config, parser, pratt, inner_body)?;
     let args = ExprList::from(vec![cond, body]);
     Ok(Expr::new_primitive_call(KeywordWhile, args))
 }
 
 fn parse_repeat<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -367,13 +367,13 @@ where
 {
     let mut inner = pair.into_inner();
     let inner_body = inner.next().map_or(internal_err!(), Ok)?.into_inner();
-    let body = parse_expr(session, parser, pratt, inner_body)?;
+    let body = parse_expr(config, parser, pratt, inner_body)?;
     let args = ExprList::from(vec![body]);
     Ok(Expr::new_primitive_call(KeywordRepeat, args))
 }
 
 fn parse_postfix<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -383,18 +383,18 @@ where
     R: RuleType + Into<en::Rule>,
 {
     match pair.as_rule().into() {
-        en::Rule::call => Ok((Expr::Null, parse_pairlist(session, parser, pratt, pair)?)),
+        en::Rule::call => Ok((Expr::Null, parse_pairlist(config, parser, pratt, pair)?)),
         en::Rule::index => {
-            let args = parse_pairlist(session, parser, pratt, pair)?;
+            let args = parse_pairlist(config, parser, pratt, pair)?;
             Ok((Expr::as_primitive(PostfixIndex), args))
         }
         en::Rule::vector_index => Ok((
             Expr::as_primitive(PostfixVecIndex),
-            parse_pairlist(session, parser, pratt, pair)?,
+            parse_pairlist(config, parser, pratt, pair)?,
         )),
 
         en::Rule::more => {
-            if session.experiments.contains(&Experiment::RestArgs) {
+            if config.experiments.contains(&Experiment::RestArgs) {
                 let val = pair.as_str();
                 Ok((Expr::Ellipsis(Some(val.to_string())), ExprList::new()))
             } else {
@@ -410,7 +410,7 @@ where
 }
 
 fn parse_postfixed<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -421,10 +421,10 @@ where
 {
     let mut inner = pair.into_inner();
     let inner_next = inner.next().map_or(internal_err!(), Ok)?;
-    let mut result = parse_primary(session, parser, pratt, inner_next)?;
+    let mut result = parse_primary(config, parser, pratt, inner_next)?;
 
     for next in inner {
-        let (what, mut args) = parse_postfix(session, parser, pratt, next)?;
+        let (what, mut args) = parse_postfix(config, parser, pratt, next)?;
         result = match what {
             // Null used here has a magic value to dispatch on `x(...)` calls
             // if postfix is parenthesized pairlist, it's a call to result
@@ -442,7 +442,7 @@ where
 }
 
 fn parse_prefixed<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -453,7 +453,7 @@ where
 {
     let mut inner = pair.into_inner().rev();
     let inner_next = inner.next().map_or(internal_err!(), Ok)?;
-    let mut result = parse_postfixed(session, parser, pratt, inner_next)?;
+    let mut result = parse_postfixed(config, parser, pratt, inner_next)?;
 
     // iterate backwards through prefixes, applying prefixes from inside-out
     for prev in inner {
@@ -464,7 +464,7 @@ where
             }
 
             en::Rule::more => {
-                if session.experiments.contains(&Experiment::RestArgs) {
+                if config.experiments.contains(&Experiment::RestArgs) {
                     Expr::Ellipsis(Some(result.to_string()))
                 } else {
                     return Err(Error::FeatureDisabledRestArgs.into());
@@ -482,7 +482,7 @@ where
 }
 
 fn parse_vec<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -491,12 +491,12 @@ where
     P: Parser<R> + LocalizedParser,
     R: RuleType + Into<en::Rule>,
 {
-    let args = parse_pairlist(session, parser, pratt, pair)?;
+    let args = parse_pairlist(config, parser, pratt, pair)?;
     Ok(Expr::new_primitive_call(PrimVec, args))
 }
 
 fn parse_list<P, R>(
-    session: &Session,
+    config: &SessionParserConfig,
     parser: &P,
     pratt: &PrattParser<R>,
     pair: Pair<R>,
@@ -505,7 +505,7 @@ where
     P: Parser<R> + LocalizedParser,
     R: RuleType + Into<en::Rule>,
 {
-    let args = parse_pairlist(session, parser, pratt, pair)?;
+    let args = parse_pairlist(config, parser, pratt, pair)?;
     Ok(Expr::List(args))
 }
 

--- a/src/parser/localization/core.rs
+++ b/src/parser/localization/core.rs
@@ -1,14 +1,14 @@
-use crate::{lang::Signal, parser::*, session::Session};
+use crate::{lang::Signal, parser::*, session::SessionParserConfig};
 
 pub type HighlightResult = Result<Vec<(String, Style)>, Signal>;
 pub trait LocalizedParser: std::marker::Sync {
-    fn parse_input_with(&self, input: &str, session: &Session) -> ParseResult;
+    fn parse_input_with(&self, input: &str, config: &SessionParserConfig) -> ParseResult;
     fn parse_input(&self, input: &str) -> ParseResult {
-        self.parse_input_with(input, &Session::default())
+        self.parse_input_with(input, &SessionParserConfig::default())
     }
-    fn parse_highlight_with(&self, input: &str, session: &Session) -> HighlightResult;
+    fn parse_highlight_with(&self, input: &str, config: &SessionParserConfig) -> HighlightResult;
     fn parse_highlight(&self, input: &str) -> HighlightResult {
-        self.parse_highlight_with(input, &Session::default())
+        self.parse_highlight_with(input, &SessionParserConfig::default())
     }
 }
 
@@ -37,27 +37,27 @@ pub enum Localization {
 }
 
 impl LocalizedParser for Localization {
-    fn parse_input_with(&self, input: &str, session: &Session) -> ParseResult {
+    fn parse_input_with(&self, input: &str, config: &SessionParserConfig) -> ParseResult {
         use Localization::*;
         match self {
-            En => LocalizedParser::parse_input_with(&en::Parser, input, session),
-            Es => LocalizedParser::parse_input_with(&es::Parser, input, session),
-            De => LocalizedParser::parse_input_with(&de::Parser, input, session),
-            Zh => LocalizedParser::parse_input_with(&zh::Parser, input, session),
-            Pirate => LocalizedParser::parse_input_with(&pirate::Parser, input, session),
-            Emoji => LocalizedParser::parse_input_with(&emoji::Parser, input, session),
+            En => LocalizedParser::parse_input_with(&en::Parser, input, config),
+            Es => LocalizedParser::parse_input_with(&es::Parser, input, config),
+            De => LocalizedParser::parse_input_with(&de::Parser, input, config),
+            Zh => LocalizedParser::parse_input_with(&zh::Parser, input, config),
+            Pirate => LocalizedParser::parse_input_with(&pirate::Parser, input, config),
+            Emoji => LocalizedParser::parse_input_with(&emoji::Parser, input, config),
         }
     }
 
-    fn parse_highlight_with(&self, input: &str, session: &Session) -> HighlightResult {
+    fn parse_highlight_with(&self, input: &str, config: &SessionParserConfig) -> HighlightResult {
         use Localization::*;
         match self {
-            En => LocalizedParser::parse_highlight_with(&en::Parser, input, session),
-            Es => LocalizedParser::parse_highlight_with(&es::Parser, input, session),
-            De => LocalizedParser::parse_highlight_with(&de::Parser, input, session),
-            Zh => LocalizedParser::parse_highlight_with(&zh::Parser, input, session),
-            Pirate => LocalizedParser::parse_highlight_with(&pirate::Parser, input, session),
-            Emoji => LocalizedParser::parse_highlight_with(&emoji::Parser, input, session),
+            En => LocalizedParser::parse_highlight_with(&en::Parser, input, config),
+            Es => LocalizedParser::parse_highlight_with(&es::Parser, input, config),
+            De => LocalizedParser::parse_highlight_with(&de::Parser, input, config),
+            Zh => LocalizedParser::parse_highlight_with(&zh::Parser, input, config),
+            Pirate => LocalizedParser::parse_highlight_with(&pirate::Parser, input, config),
+            Emoji => LocalizedParser::parse_highlight_with(&emoji::Parser, input, config),
         }
     }
 }

--- a/src/repl/headless.rs
+++ b/src/repl/headless.rs
@@ -7,7 +7,7 @@ use crate::context::Context;
 use crate::lang::{CallStack, Cond, Signal};
 use crate::object::Environment;
 use crate::parser::*;
-use crate::session::{Session, SessionOutput};
+use crate::session::{Session, SessionOutput, SessionParserConfig};
 
 #[wasm_bindgen]
 pub struct ParseError {
@@ -135,7 +135,8 @@ pub fn wasm_highlight(args: JsValue, input: &str) -> Vec<JsValue> {
 }
 
 pub fn wasm_eval_in(args: &Session, env: &Rc<Environment>, input: &str) -> Option<String> {
-    match args.locale.parse_input_with(input, args) {
+    let parser_config: SessionParserConfig = args.clone().into();
+    match parser_config.locale.parse_input_with(input, &parser_config) {
         Ok(expr) => {
             let mut stack = CallStack::from(args.clone()).with_global_env(env.clone());
             match stack.eval_and_finalize(expr) {

--- a/src/repl/highlight.rs
+++ b/src/repl/highlight.rs
@@ -3,11 +3,30 @@ use reedline::Highlighter;
 use reedline::StyledText;
 
 use crate::parser::*;
+use crate::session::SessionParserConfig;
 
 impl Highlighter for Localization {
     fn highlight(&self, line: &str, _pos: usize) -> StyledText {
         let mut styled_text = StyledText::new();
         match self.parse_highlight(line) {
+            Ok(pairs) => {
+                for (text, style) in pairs.into_iter() {
+                    styled_text.push((style.into(), text));
+                }
+                styled_text
+            }
+            Err(_) => {
+                styled_text.push((Style::new(), line.to_string()));
+                styled_text
+            }
+        }
+    }
+}
+
+impl Highlighter for SessionParserConfig {
+    fn highlight(&self, line: &str, _pos: usize) -> StyledText {
+        let mut styled_text = StyledText::new();
+        match self.locale.parse_highlight_with(line, self) {
             Ok(pairs) => {
                 for (text, style) in pairs.into_iter() {
                     styled_text.push((style.into(), text));

--- a/src/repl/release.rs
+++ b/src/repl/release.rs
@@ -1,4 +1,5 @@
-use crate::{parser::Localization, session::Session};
+use crate::{cli::Experiment, parser::Localization, session::Session};
+use strum::IntoEnumIterator;
 
 pub const RELEASE_NAME: &str = "Beautiful You";
 
@@ -35,7 +36,6 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.");
 }
 
-#[allow(clippy::const_is_empty)]
 pub fn session_header(session: &Session) -> String {
     let dev = if !GIT_HASH.is_empty() {
         format!(" (dev {:.8})", GIT_HASH)
@@ -49,9 +49,25 @@ pub fn session_header(session: &Session) -> String {
         COPYRIGHT.as_str()
     };
 
-    if session.locale == Localization::Pirate {
-        format!("Arr version {RELEASE_VERSION} -- \"{RELEASE_NAME}\"{dev}\n{license_info}\n",)
+    let experiments: String = {
+        let exp_strs: Vec<String> = Experiment::iter()
+            .map(|exp| {
+                if session.experiments.contains(&exp) {
+                    format!("  [x] {exp:?}")
+                } else {
+                    format!("  [ ] {exp:?}")
+                }
+            })
+            .collect();
+
+        format!("\nExperiments:\n{}", exp_strs.join("\n"))
+    };
+
+    let langname = if session.locale == Localization::Pirate {
+        "Arr"
     } else {
-        format!("R version {RELEASE_VERSION} -- \"{RELEASE_NAME}\"{dev}\n{license_info}\n",)
-    }
+        "R"
+    };
+
+    format!("{langname} version {RELEASE_VERSION} -- \"{RELEASE_NAME}\"{dev}\n{license_info}\n{experiments}\n",)
 }

--- a/src/repl/release.rs
+++ b/src/repl/release.rs
@@ -36,6 +36,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.");
 }
 
+#[allow(clippy::const_is_empty)]
 pub fn session_header(session: &Session) -> String {
     let dev = if !GIT_HASH.is_empty() {
         format!(" (dev {:.8})", GIT_HASH)

--- a/src/repl/validator.rs
+++ b/src/repl/validator.rs
@@ -1,9 +1,19 @@
-use crate::parser::*;
+use crate::{parser::*, session::SessionParserConfig};
 use reedline::{ValidationResult, Validator};
 
 impl Validator for Localization {
     fn validate(&self, line: &str) -> ValidationResult {
         let res = self.parse_input(line);
+        match res {
+            Ok(_) => ValidationResult::Complete,
+            Err(_) => ValidationResult::Incomplete,
+        }
+    }
+}
+
+impl Validator for SessionParserConfig {
+    fn validate(&self, line: &str) -> ValidationResult {
+        let res = self.locale.parse_input_with(line, self);
         match res {
             Ok(_) => ValidationResult::Complete,
             Err(_) => ValidationResult::Incomplete,

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,6 +17,22 @@ pub enum SessionOutput {
     Callback(Rc<dyn Fn(String)>),
 }
 
+// A subset of the Session info that is thread-safe for passing to reedline::{Validator, Highlighter}
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SessionParserConfig {
+    pub locale: Localization,
+    pub experiments: Vec<Experiment>,
+}
+
+impl From<Session> for SessionParserConfig {
+    fn from(val: Session) -> Self {
+        SessionParserConfig {
+            locale: val.locale,
+            experiments: val.experiments,
+        }
+    }
+}
+
 impl std::fmt::Debug for SessionOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -75,6 +91,11 @@ impl Session {
 
     pub fn with_output(mut self, output: SessionOutput) -> Session {
         self.output = output;
+        self
+    }
+
+    pub fn with_experiments(mut self, experiments: Vec<Experiment>) -> Session {
+        self.experiments = experiments;
         self
     }
 }


### PR DESCRIPTION
When I was adding the localization I accidentally forgot to pass experiments down to the repl validator and highlighter. This had the odd result of breaking in the terminal, but not in wasm where we skip the reedline repl and use the internals directly to build our own repl. 

Now both repls should allow `--experiments` again

