### PR TITLE
fix: parenthesis now appear in printed quote objects

### DIFF
--- a/r_derive/src/lib.rs
+++ b/r_derive/src/lib.rs
@@ -77,7 +77,11 @@ pub fn builtin(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             #[automatically_derived]
-            impl Builtin for #what {}
+            impl Builtin for #what {
+                fn kind(&self) -> SymKind {
+                    SymKind::#kind
+                }
+            }
         },
         Builtin::Keyword => quote! {
             #item
@@ -96,6 +100,10 @@ pub fn builtin(attr: TokenStream, item: TokenStream) -> TokenStream {
             impl Builtin for #what {
                 fn is_transparent(&self) -> bool {
                     true
+                }
+
+                fn kind(&self) -> SymKind {
+                    SymKind::Keyword
                 }
             }
         },

--- a/src/callable/core.rs
+++ b/src/callable/core.rs
@@ -194,6 +194,14 @@ pub trait Builtin: Callable + CallableClone + Format + DynCompare + Sync {
     fn is_transparent(&self) -> bool {
         false
     }
+
+    fn is_infix(&self) -> bool {
+        self.kind() == SymKind::Infix
+    }
+
+    fn kind(&self) -> SymKind {
+        SymKind::Function
+    }
 }
 
 pub trait Sym {
@@ -201,7 +209,9 @@ pub trait Sym {
     const KIND: &'static SymKind;
 }
 
+#[derive(PartialEq)]
 pub enum SymKind {
+    Keyword,
     Function,
     Infix,
     Prefix,
@@ -233,6 +243,7 @@ where
                 let rest = args.collect::<ExprList>();
                 format!("{}{l}{}{r}", first.1, rest)
             }
+            Keyword => sym.to_string(), // keywords generally implement their own formatter
         }
     }
 

--- a/src/callable/keywords.rs
+++ b/src/callable/keywords.rs
@@ -211,6 +211,27 @@ impl Callable for KeywordRepeat {
 
 #[derive(Debug, Clone, PartialEq)]
 #[builtin]
+pub struct KeywordParen;
+
+impl Format for KeywordParen {
+    fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
+        format!("({})", args.values.first().unwrap())
+    }
+
+    fn rfmt_with(&self, _: FormatState) -> String {
+        "(".to_string()
+    }
+}
+
+impl Callable for KeywordParen {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let expr = args.values.into_iter().next().unwrap();
+        stack.eval_and_finalize(expr)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[builtin]
 pub struct KeywordBlock;
 
 impl Format for KeywordBlock {
@@ -245,6 +266,7 @@ impl Callable for KeywordBlock {
         Ok(value)
     }
 }
+
 #[cfg(test)]
 mod test {
     use crate::r;

--- a/src/callable/primitive/substitute.rs
+++ b/src/callable/primitive/substitute.rs
@@ -67,7 +67,7 @@ impl Callable for PrimitiveSubstitute {
         fn substitute(expr: Expr, env: &Environment, paren: bool) -> Expr {
             match expr {
                 Symbol(s) => {
-                    // promises are replaced, not sure if correct behavior
+                    // promise expressions (ie arguments) are replaced with their unevaluated expressions
                     match env.values.borrow().get(&s) {
                         Some(Obj::Expr(expr)) | Some(Obj::Promise(_, expr, _)) => {
                             if paren {

--- a/src/grammar/grammar.pest
+++ b/src/grammar/grammar.pest
@@ -121,7 +121,7 @@
             block_exprs = { WS* ~ expr? ~ ( block_sep+ ~ expr? )* ~ WS* }
             block_sep = _{ WS_NO_NL* ~ ( ";" | comment? ~ NEWLINE ) ~ WS* }
 
-        paren_expr = _{ "(" ~ WS* ~ expr ~ WS* ~ ")" }
+        paren_expr = { "(" ~ WS* ~ expr ~ WS* ~ ")" }
 
         atom = _{
               block

--- a/src/object/ast.rs
+++ b/src/object/ast.rs
@@ -85,7 +85,7 @@ impl fmt::Display for Expr {
             Expr::Call(what, args) => match &**what {
                 Expr::Primitive(p) => write!(f, "{}", p.rfmt_call(args)),
                 Expr::String(s) | Expr::Symbol(s) => write!(f, "{}({})", s, args),
-                rexpr => write!(f, "({})({})", rexpr, args),
+                rexpr => write!(f, "{}({})", rexpr, args),
             },
             Expr::Function(head, body) => write!(f, "function({}) {}", head, body),
             Expr::Primitive(p) => write!(f, "Primitive(\"{}\")", p.rfmt()),


### PR DESCRIPTION
This one ended up exposing a few other bugs related to handling of parenthesis. 

Before they weren't actually part of the syntax tree. They just existed through the structure of the tree itself - implicit to the interpreter but non-obvious when printed. Anything that looked like it printed reasonably before was just little tricks I had shoved in to make it look reasonable along the way.

Now parenthesis have their own symbol so this should be much more rigorously handled in the future.

I also spent a little time cleaning up `substitute()`, which does some "automatic" parentheses insertion when operator precedence might affect behaviors, similar to R.