### PR TITLE
fix: nested promises force and finalize any lingering tails

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -66,7 +66,7 @@ impl Obj {
         match self {
             Obj::Promise(None, expr, env) => {
                 stack.add_frame(expr.clone(), env.clone());
-                let result = stack.eval(expr);
+                let result = stack.eval_and_finalize(expr);
                 stack.pop_frame_and_return(result)
             }
             Obj::Promise(Some(value), ..) => Ok(*value),
@@ -1064,6 +1064,15 @@ mod test {
             f <- fn(x) {x; null}
             f(x = 2)
             x == 1
+        "}}
+    }
+
+    #[test]
+    fn fn_assign_in_arg_forces_all_promises() {
+        r_expect! {{"
+            f <- fn(x) { x }
+            z <- f({ y <- 123 })
+            z == 123 && y == 123
         "}}
     }
 


### PR DESCRIPTION
Promises were evaluating, but not _finalizing_ their expressions, which can result in un-evaluated tail-calls in the case of nested promises.

Now they are also _finalized_

Closes #141