### PR TITLE
Feature: Generalize ellipsis as a `..rest` argument (when `rest-args` enabled)

### DIFF
--- a/r_derive/src/lib.rs
+++ b/r_derive/src/lib.rs
@@ -237,7 +237,6 @@ pub fn derive_translate(_input: TokenStream) -> TokenStream {
                     Rule::symbol_ident => en::Rule::symbol_ident,
                     Rule::list => en::Rule::list,
                     Rule::pairs => en::Rule::pairs,
-                    // Rule::ellipsis => en::Rule::ellipsis,
                     Rule::elem => en::Rule::elem,
                     Rule::named => en::Rule::named,
                     Rule::vec => en::Rule::vec,

--- a/src/callable/core.rs
+++ b/src/callable/core.rs
@@ -2,6 +2,7 @@ extern crate r_derive;
 
 use crate::callable::builtins::BUILTIN;
 use crate::callable::dyncompare::*;
+use crate::cli::Experiment;
 use crate::context::Context;
 use crate::error::Error;
 use crate::object::List;
@@ -333,7 +334,10 @@ impl Callable for Obj {
             return internal_err!();
         };
 
-        stack.env().insert("...".to_string(), Obj::List(ellipsis));
+        if !stack.session.experiments.contains(&Experiment::RestArgs) {
+            stack.env().insert("...".to_string(), Obj::List(ellipsis));
+        }
+
         stack.env().append(args);
         stack.eval(body.clone())
     }

--- a/src/callable/primitive/names.rs
+++ b/src/callable/primitive/names.rs
@@ -35,7 +35,6 @@ impl Callable for PrimitiveNames {
             }
             Environment(e) => {
                 let mut names = e.values.borrow().keys().cloned().collect::<Vec<String>>();
-
                 names.sort();
                 Ok(names.into())
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,7 @@ pub enum Error {
     // function parsing
     InvalidFunctionParameter(Expr),
     DuplicatedParameter(String),
+    DuplicatedMoreParameter(),
 
     Missing,
     ArgumentMissing(String),
@@ -117,6 +118,7 @@ impl Error {
             Error::Missing => "object is missing".to_string(),
             Error::InvalidFunctionParameter(expr) => format!("invalid function parameter: {}", expr),
             Error::DuplicatedParameter(name) => format!("duplicated parameter name: {}", name),
+            Error::DuplicatedMoreParameter() => "duplicated '..<more>' parameters".to_string(),
         }
     }
 

--- a/src/grammar/grammar.pest
+++ b/src/grammar/grammar.pest
@@ -193,8 +193,6 @@
 
     list = { "(" ~ pairs ~ ")" }
         pairs = _{ ( ( WS* ~ elem ~ WS* ~ "," )* ~ WS* ~ elem? )? ~ WS* }
-        // ellipsis = { "..." }
-        // elem = _{ ellipsis | named | expr }
         elem = _{ named | expr }
         named = { symbol ~ WS* ~ "=" ~ WS* ~ expr? }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1074,7 +1074,11 @@ pub fn assert_formals(session: &Session, formals: ExprList) -> Result<ExprList, 
     }
 
     if ellipsis > 1 {
-        return Error::DuplicatedParameter("...".to_string()).into();
+        if allow_rest_args {
+            return Error::DuplicatedParameter("...".to_string()).into();
+        } else {
+            return Error::DuplicatedMoreParameter().into();
+        }
     }
 
     Ok(formals)

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -106,14 +106,7 @@ where
         en::Rule::val_inf => Ok(Expr::Inf),
 
         // reserved symbols
-        en::Rule::ellipsis => Ok(Expr::Ellipsis(None)),
-        en::Rule::more => {
-            if config.experiments.contains(&Experiment::RestArgs) {
-                Ok(Expr::More)
-            } else {
-                Err(Error::FeatureDisabledRestArgs.into())
-            }
-        }
+        en::Rule::more => Ok(Expr::More),
 
         // atomic values
         en::Rule::number => Ok(Expr::Number(

--- a/src/parser/localization/core.rs
+++ b/src/parser/localization/core.rs
@@ -61,3 +61,37 @@ impl LocalizedParser for Localization {
         }
     }
 }
+
+impl LocalizedParser for SessionParserConfig {
+    fn parse_input_with(&self, _input: &str, _config: &SessionParserConfig) -> ParseResult {
+        unimplemented!()
+    }
+
+    fn parse_input(&self, input: &str) -> ParseResult {
+        use Localization::*;
+        match self.locale {
+            En => LocalizedParser::parse_input_with(&en::Parser, input, self),
+            Es => LocalizedParser::parse_input_with(&es::Parser, input, self),
+            De => LocalizedParser::parse_input_with(&de::Parser, input, self),
+            Zh => LocalizedParser::parse_input_with(&zh::Parser, input, self),
+            Pirate => LocalizedParser::parse_input_with(&pirate::Parser, input, self),
+            Emoji => LocalizedParser::parse_input_with(&emoji::Parser, input, self),
+        }
+    }
+
+    fn parse_highlight_with(&self, _input: &str, _config: &SessionParserConfig) -> HighlightResult {
+        unimplemented!()
+    }
+
+    fn parse_highlight(&self, input: &str) -> HighlightResult {
+        use Localization::*;
+        match self.locale {
+            En => LocalizedParser::parse_highlight_with(&en::Parser, input, self),
+            Es => LocalizedParser::parse_highlight_with(&es::Parser, input, self),
+            De => LocalizedParser::parse_highlight_with(&de::Parser, input, self),
+            Zh => LocalizedParser::parse_highlight_with(&zh::Parser, input, self),
+            Pirate => LocalizedParser::parse_highlight_with(&pirate::Parser, input, self),
+            Emoji => LocalizedParser::parse_highlight_with(&emoji::Parser, input, self),
+        }
+    }
+}

--- a/src/repl/headless.rs
+++ b/src/repl/headless.rs
@@ -136,7 +136,7 @@ pub fn wasm_highlight(args: JsValue, input: &str) -> Vec<JsValue> {
 
 pub fn wasm_eval_in(args: &Session, env: &Rc<Environment>, input: &str) -> Option<String> {
     let parser_config: SessionParserConfig = args.clone().into();
-    match parser_config.locale.parse_input_with(input, &parser_config) {
+    match parser_config.parse_input(input) {
         Ok(expr) => {
             let mut stack = CallStack::from(args.clone()).with_global_env(env.clone());
             match stack.eval_and_finalize(expr) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,16 +13,16 @@ impl<T, U> SameType<T> for U {
 #[macro_export]
 macro_rules! r {
     // evaluate a single token directly
-    {{ $expr:tt }} => {{
+    {{ $expr:literal }} => {{
         {
             // test if token is a string literal and evaluate directly
             if let Some(s) = (&$expr as &dyn std::any::Any).downcast_ref::<&str>() {
-                $crate::repl::eval(&s)
+                $crate::lang::CallStack::default().parse_and_eval(s)
 
             // otherwise stringify token before evaluating
             } else {
                 let expr = stringify!($expr);
-                $crate::repl::eval(expr)
+                $crate::lang::CallStack::default().parse_and_eval(expr)
             }
         }
     }};
@@ -32,7 +32,7 @@ macro_rules! r {
     { $($expr:tt)+ } => {{
         {
             let expr = stringify!($($expr)+);
-            $crate::repl::eval(expr)
+            $crate::lang::CallStack::default().parse_and_eval(expr)
         }
     }};
 }
@@ -44,12 +44,14 @@ macro_rules! r_expect {
         {
             // test if token is a string literal and evaluate directly
             if let Some(s) = (&$expr as &dyn std::any::Any).downcast_ref::<&str>() {
-                assert_eq!($crate::repl::eval(&s), r!{ true })
+                let res  = $crate::lang::CallStack::default().parse_and_eval(s);
+                assert_eq!(res, r!{ true })
 
             // otherwise stringify token before evaluating
             } else {
                 let expr = stringify!($expr);
-                assert_eq!($crate::repl::eval(expr), r!{ true })
+                let res  = $crate::lang::CallStack::default().parse_and_eval(expr);
+                assert_eq!(res, r!{ true })
             }
         }
     }};
@@ -59,7 +61,8 @@ macro_rules! r_expect {
     { $($expr:tt)+ } => {{
         {
             let expr = stringify!($($expr)+);
-            assert_eq!($crate::repl::eval(expr), r!{ true })
+            let res  = $crate::lang::CallStack::default().parse_and_eval(expr);
+            assert_eq!(res, r!{ true })
         }
     }};
 }


### PR DESCRIPTION
Closes #133; Inspired by the discussion in #133

### _vanilla_

```r
f <- fn(...) list(...)
f(1, 2, 3)
# list(1, 2, 3)

f <- fn(...) .
f(1, 2, 3)
# Error: object '.' not found
```

### `rest-args`

```r
f <- fn(...) list(...)
f(1, 2, 3)
# list(1, 2, 3)

f <- fn(...) .
f(1, 2, 3)
# list(1, 2, 3)
```

* Treats `...` as a "rest" argument, similar to any other "rest" argument using the "more" operator (`..`). When the `rest-args` experiment is enabled, `...` gets parsed as a _named_ ellipsis argument with the name `.`.

### Other enhancements

* Adds `parse`, and `parse_and_eval` as methods of `CallStack` to make it easier to write tests that make use of experiments
* Cleans up some legacy uses of `session.local.parse_input_with` and replaces with `parser_config.parse_input`
* Fixes feature disabled error message to display correct command to enabled features.
* `CallStack::default()` now defaults to a global environment with pre-populated builtin functions instead of an empty environment.
* Renamed `parse_pairlist` to `parse_list_elements` since we don't use a lisp-style "pairlist"