### PR TITLE
fix: assignment of list to list subset

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -217,7 +217,7 @@ impl Obj {
         match self {
             Obj::Vector(v) => v.get(index).map(Obj::Vector),
             Obj::Null => None,
-            Obj::List(..) => None,
+            Obj::List(l) => l.values.borrow().get(index).map(|x| x.1.clone()),
             Obj::Expr(..) => None,
             Obj::Promise(..) => None,
             Obj::Function(..) => None,


### PR DESCRIPTION
Implement `Obj.get` for `List`, necessary for `<list>[<indices>] <- <list>` to function properly.