### PR TITLE
fix: lists parsed as call to primitive instead of Expr::List

### DIFF
--- a/src/callable/operators.rs
+++ b/src/callable/operators.rs
@@ -431,3 +431,20 @@ impl Callable for PrimVec {
         super::primitive::PrimitiveC.call(args, stack)
     }
 }
+
+#[derive(Debug, Clone, PartialEq)]
+#[builtin]
+pub struct PrimList;
+
+impl Format for PrimList {
+    fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
+        let trailing_comma = if args.len() > 1 { "" } else { "," };
+        format!("({}{})", args, trailing_comma)
+    }
+}
+
+impl Callable for PrimList {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        super::primitive::PrimitiveList.call(args, stack)
+    }
+}

--- a/src/context/core.rs
+++ b/src/context/core.rs
@@ -133,7 +133,7 @@ pub trait Context: std::fmt::Debug + std::fmt::Display {
                             Ok(CowObj::from(vec![]).into_iter())
                         }
                     }
-                    (k, v) => match self.eval(v) {
+                    (k, v) => match self.eval_and_finalize(v) {
                         Ok(elem) => Ok(CowObj::from(vec![(k, elem)]).into_iter()),
                         Err(e) => Err(e),
                     },

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -527,8 +527,9 @@ where
     P: Parser<R> + LocalizedParser,
     R: RuleType + Into<en::Rule>,
 {
+    use crate::callable::primitive::PrimitiveList;
     let args = parse_list_elements(config, parser, pratt, pair)?;
-    Ok(Expr::List(args))
+    Ok(Expr::new_primitive_call(PrimitiveList, args))
 }
 
 #[cfg(test)]

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -527,9 +527,8 @@ where
     P: Parser<R> + LocalizedParser,
     R: RuleType + Into<en::Rule>,
 {
-    use crate::callable::primitive::PrimitiveList;
     let args = parse_list_elements(config, parser, pratt, pair)?;
-    Ok(Expr::new_primitive_call(PrimitiveList, args))
+    Ok(Expr::new_primitive_call(PrimList, args))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This might be a change we revert at some point if we ever want to return lazy list elements, but for now it has the intended behavior.

Like the vector syntax `[1, 2, 3]`, we now have a list syntax primitive `(1, 2, 3)` which knows to evaluate similar to `PrimitiveList`.