### PR TITLE
fix: implement missing negation operator

### DIFF
--- a/r_derive/src/lib.rs
+++ b/r_derive/src/lib.rs
@@ -195,7 +195,7 @@ pub fn derive_translate(_input: TokenStream) -> TokenStream {
                     Rule::doublecolon => en::Rule::doublecolon,
                     Rule::triplecolon => en::Rule::triplecolon,
                     Rule::prefix => en::Rule::prefix,
-                    Rule::negate => en::Rule::negate,
+                    Rule::not => en::Rule::not,
                     Rule::postfix => en::Rule::postfix,
                     Rule::call => en::Rule::call,
                     Rule::index => en::Rule::index,

--- a/src/callable/builtins.rs
+++ b/src/callable/builtins.rs
@@ -18,6 +18,7 @@ lazy_static! {
             ("+", Box::new(InfixAdd) as Box<dyn Builtin>),
             ("-", Box::new(InfixSub) as Box<dyn Builtin>),
             ("-", Box::new(PrefixSub) as Box<dyn Builtin>),
+            ("!", Box::new(PrefixNot) as Box<dyn Builtin>),
             ("..", Box::new(PrefixPack) as Box<dyn Builtin>),
             ("*", Box::new(InfixMul) as Box<dyn Builtin>),
             ("/", Box::new(InfixDiv) as Box<dyn Builtin>),

--- a/src/callable/operators.rs
+++ b/src/callable/operators.rs
@@ -48,6 +48,16 @@ impl Callable for PrefixSub {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[builtin(sym = "!", kind = Prefix)]
+pub struct PrefixNot;
+impl Callable for PrefixNot {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        let what = stack.eval(args.unnamed_unary_arg())?;
+        !what
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "..", kind = Prefix)]
 pub struct PrefixPack;
 impl Callable for PrefixPack {

--- a/src/grammar/grammar.pest
+++ b/src/grammar/grammar.pest
@@ -107,8 +107,8 @@
             triplecolon = { ":::" }
             more = { ".." }
 
-        prefix = _{ subtract | negate | more }
-            negate = { "!" }
+        prefix = _{ subtract | not | more }
+            not = { "!" }
 
         postfix = _{ call | index | vector_index | more }
             call         = { "("  ~ pairs ~  ")" }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -453,6 +453,17 @@ impl std::ops::Neg for Obj {
     }
 }
 
+impl std::ops::Not for Obj {
+    type Output = EvalResult;
+
+    fn not(self) -> Self::Output {
+        match self.as_logical()? {
+            Obj::Vector(x) => Ok(Obj::Vector(!x)),
+            _ => internal_err!(),
+        }
+    }
+}
+
 impl std::ops::Mul for Obj {
     type Output = EvalResult;
 

--- a/src/object/vector/core.rs
+++ b/src/object/vector/core.rs
@@ -573,6 +573,13 @@ impl std::ops::BitAnd<Logical> for Logical {
     }
 }
 
+impl std::ops::Not for Logical {
+    type Output = Logical;
+    fn not(self) -> Self::Output {
+        self.map(|x| !x)
+    }
+}
+
 impl std::ops::Neg for Vector {
     type Output = Vector;
     fn neg(self) -> Self::Output {
@@ -581,6 +588,17 @@ impl std::ops::Neg for Vector {
             Double(x) => Double(x.neg()),
             Integer(x) => Integer(x.neg()),
             Logical(x) => Integer(x.neg()),
+            _ => todo!(),
+        }
+    }
+}
+
+impl std::ops::Not for Vector {
+    type Output = Vector;
+    fn not(self) -> Self::Output {
+        use Vector::*;
+        match self {
+            Logical(x) => (!x).into(),
             _ => todo!(),
         }
     }

--- a/src/object/vector/rep.rs
+++ b/src/object/vector/rep.rs
@@ -552,6 +552,20 @@ where
     }
 }
 
+impl<L, O> std::ops::Not for Rep<L>
+where
+    L: AtomicMode + Default + Clone + CoercibleInto<Logical>,
+    Logical: std::ops::Not<Output = O>,
+    RepType<O>: From<Vec<O>>,
+    O: Clone,
+{
+    type Output = Rep<O>;
+    fn not(self) -> Self::Output {
+        let result: RepType<O> = !self.0.into_inner();
+        Rep(RefCell::new(result))
+    }
+}
+
 impl<L, R, C> VecPartialCmp<Rep<R>> for Rep<L>
 where
     L: AtomicMode + Default + Clone + CoercibleInto<C>,

--- a/src/object/vector/reptype.rs
+++ b/src/object/vector/reptype.rs
@@ -631,6 +631,24 @@ where
     }
 }
 
+impl<L, O> std::ops::Not for RepType<L>
+where
+    L: AtomicMode + Default + Clone + CoercibleInto<Logical>,
+    Logical: std::ops::Not<Output = O>,
+    RepType<O>: From<Vec<O>>,
+    O: Clone,
+{
+    type Output = RepType<O>;
+    fn not(self) -> Self::Output {
+        RepType::from(
+            self.inner()
+                .iter()
+                .map(|l| CoercibleInto::<Logical>::coerce_into(l.clone()).not())
+                .collect::<Vec<O>>(),
+        )
+    }
+}
+
 impl<L, R, C> VecPartialCmp<RepType<R>> for RepType<L>
 where
     L: AtomicMode + Default + Clone + CoercibleInto<C>,

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -482,6 +482,11 @@ where
                 Expr::new_primitive_call(PrefixSub, args)
             }
 
+            en::Rule::not => {
+                let args = ExprList::from(vec![result]);
+                Expr::new_primitive_call(PrefixNot, args)
+            }
+
             en::Rule::more => {
                 let is_ellipsis = result.to_string() == ".";
                 if config.experiments.contains(&Experiment::RestArgs) {


### PR DESCRIPTION
Somehow missed the implementation of `!`. Now added. Also updated all the internal naming conventions to use "not" instead of what was mistakenly called "negate" :sweat_smile: 