### PR TITLE
Fix: Mutating promises materializes value

### DIFF
--- a/src/callable/primitive/substitute.rs
+++ b/src/callable/primitive/substitute.rs
@@ -76,6 +76,7 @@ impl Callable for PrimitiveSubstitute {
                                 expr.clone()
                             }
                         }
+                        // NOTE: In R, substitute will further replace with deparsed values
                         _ => Symbol(s),
                     }
                 }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -907,13 +907,14 @@ impl Context for CallStack {
     }
 
     fn get_mut(&mut self, name: String) -> EvalResult {
-        let (obj, env) = self.find(name.clone())?;
+        let (obj, _env) = self.find(name.clone())?;
 
-        if self.env() == env {
-            return Ok(obj);
-        }
+        let objc = match obj {
+            // when accessed mutably, promises are masked by materialized value
+            Obj::Promise(Some(x), ..) => *x.clone(),
+            _ => obj.clone(),
+        };
 
-        let objc = obj.clone();
         self.env().insert(name, objc.view_mut());
         Ok(objc)
     }
@@ -1318,6 +1319,7 @@ mod test {
             f()
             x == 10
         "}}
+
         r_expect! {{"
              f = fn(x) {
                x[1] <- -99
@@ -1326,7 +1328,7 @@ mod test {
              x1 = 10
              x2 = f(x1)
              (x1 == 10) && x2 == -99
-         "}}
+        "}}
     }
 
     #[test]
@@ -1338,21 +1340,15 @@ mod test {
             }
             x2 = f(c(1, 2))
             (x2[1] == -99) && (x2[2] == 2)
-         "}}
+        "}}
     }
 
-    // TODO: https://github.com/dgkf/R/issues/136
-    // #[test]
-    // fn nested_promises_can_be_mutated() {
-    //     r_expect! {{"
-    //         inc = fn(x) {
-    //           x[1] = x[1] + 1
-    //           x
-    //         }
-    //         add_two = fn(x) {
-    //           inc(inc(x))
-    //         }
-    //         add_two(1) == 3
-    //      "}}
-    // }
+    #[test]
+    fn nested_promises_can_be_mutated() {
+        r_expect! {{"
+            inc = fn(x) { x[1] = x[1] + 1; x }
+            add_two = fn(x) { inc(inc(x)) }
+            add_two(1) == 3
+        "}}
+    }
 }


### PR DESCRIPTION
Closes #136

Resolving a bug where accessing a promise mutably didn't prompt the actual value of the promise to be updated. Now promises, when accessed mutably on the lhs of assignment, will mask themselves with their materialized value.

