### PR TITLE
:fallen_leaf: :broom: cleanup experiments

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+struct_lit_width = 50

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,12 +424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,7 +605,6 @@ dependencies = [
  "gloo-utils",
  "hashbrown",
  "js-sys",
- "lazy_static",
  "nu-ansi-term",
  "pest",
  "pest_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ r_derive = { path = "r_derive" }
 # parser
 pest = "2.7.10"
 pest_derive = "2.7.10"
-lazy_static = "1.4.0"
 
 # rng
 rand = "0.8.5"

--- a/r_derive/src/lib.rs
+++ b/r_derive/src/lib.rs
@@ -27,12 +27,7 @@ impl Parse for Builtin {
 
         for var in vars {
             match (var.path, var.value) {
-                (
-                    k,
-                    Expr::Lit(ExprLit {
-                        lit: Lit::Str(s), ..
-                    }),
-                ) => match k {
+                (k, Expr::Lit(ExprLit { lit: Lit::Str(s), .. })) => match k {
                     sym if sym.is_ident("sym") => symbol = Some(s),
                     _ => (),
                 },

--- a/src/callable/builtins.rs
+++ b/src/callable/builtins.rs
@@ -8,8 +8,8 @@ use crate::callable::primitive::*;
 use hashbrown::HashMap;
 use std::sync::LazyLock;
 
+#[rustfmt::skip]
 pub static BUILTIN: LazyLock<HashMap<&'static str, Box<dyn Builtin>>> = LazyLock::new(|| {
-    #[rustfmt::skip]
     HashMap::from([
         // automatically populated on build. see build.rs // builtins start
         ("<-", Box::new(InfixAssign) as Box<dyn Builtin>),

--- a/src/callable/builtins.rs
+++ b/src/callable/builtins.rs
@@ -9,6 +9,7 @@ use hashbrown::HashMap;
 use std::sync::LazyLock;
 
 pub static BUILTIN: LazyLock<HashMap<&'static str, Box<dyn Builtin>>> = LazyLock::new(|| {
+    #[rustfmt::skip]
     HashMap::from([
         // automatically populated on build. see build.rs // builtins start
         ("<-", Box::new(InfixAssign) as Box<dyn Builtin>),

--- a/src/callable/builtins.rs
+++ b/src/callable/builtins.rs
@@ -2,61 +2,57 @@
 ///
 /// The contents of this file are built by build.rs
 ///
-use hashbrown::HashMap;
-
-use ::lazy_static::lazy_static;
-
 use crate::callable::core::Builtin;
 use crate::callable::operators::*;
 use crate::callable::primitive::*;
+use hashbrown::HashMap;
+use std::sync::LazyLock;
 
-lazy_static! {
-    pub static ref BUILTIN: HashMap<&'static str, Box<dyn Builtin>> = {
-        HashMap::from([
-            // automatically populated on build. see build.rs // builtins start
-            ("<-", Box::new(InfixAssign) as Box<dyn Builtin>),
-            ("+", Box::new(InfixAdd) as Box<dyn Builtin>),
-            ("-", Box::new(InfixSub) as Box<dyn Builtin>),
-            ("-", Box::new(PrefixSub) as Box<dyn Builtin>),
-            ("!", Box::new(PrefixNot) as Box<dyn Builtin>),
-            ("..", Box::new(PrefixPack) as Box<dyn Builtin>),
-            ("*", Box::new(InfixMul) as Box<dyn Builtin>),
-            ("/", Box::new(InfixDiv) as Box<dyn Builtin>),
-            ("^", Box::new(InfixPow) as Box<dyn Builtin>),
-            ("%", Box::new(InfixMod) as Box<dyn Builtin>),
-            ("||", Box::new(InfixOr) as Box<dyn Builtin>),
-            ("&&", Box::new(InfixAnd) as Box<dyn Builtin>),
-            ("|", Box::new(InfixVectorOr) as Box<dyn Builtin>),
-            ("&", Box::new(InfixVectorAnd) as Box<dyn Builtin>),
-            (">", Box::new(InfixGreater) as Box<dyn Builtin>),
-            (">=", Box::new(InfixGreaterEqual) as Box<dyn Builtin>),
-            ("<", Box::new(InfixLess) as Box<dyn Builtin>),
-            ("<=", Box::new(InfixLessEqual) as Box<dyn Builtin>),
-            ("==", Box::new(InfixEqual) as Box<dyn Builtin>),
-            ("!=", Box::new(InfixNotEqual) as Box<dyn Builtin>),
-            ("|>", Box::new(InfixPipe) as Box<dyn Builtin>),
-            (":", Box::new(InfixColon) as Box<dyn Builtin>),
-            ("$", Box::new(InfixDollar) as Box<dyn Builtin>),
-            ("..", Box::new(PostfixPack) as Box<dyn Builtin>),
-            ("[[", Box::new(PostfixIndex) as Box<dyn Builtin>),
-            ("[", Box::new(PostfixVecIndex) as Box<dyn Builtin>),
-            ("c", Box::new(PrimitiveC) as Box<dyn Builtin>),
-            ("callstack", Box::new(PrimitiveCallstack) as Box<dyn Builtin>),
-            ("environment", Box::new(PrimitiveEnvironment) as Box<dyn Builtin>),
-            ("eval", Box::new(PrimitiveEval) as Box<dyn Builtin>),
-            ("length", Box::new(PrimitiveLength) as Box<dyn Builtin>),
-            ("list", Box::new(PrimitiveList) as Box<dyn Builtin>),
-            ("names", Box::new(PrimitiveNames) as Box<dyn Builtin>),
-            ("parent", Box::new(PrimitiveParent) as Box<dyn Builtin>),
-            ("paste", Box::new(PrimitivePaste) as Box<dyn Builtin>),
-            ("print", Box::new(PrimitivePrint) as Box<dyn Builtin>),
-            ("q", Box::new(PrimitiveQ) as Box<dyn Builtin>),
-            ("quote", Box::new(PrimitiveQuote) as Box<dyn Builtin>),
-            ("rnorm", Box::new(PrimitiveRnorm) as Box<dyn Builtin>),
-            ("runif", Box::new(PrimitiveRunif) as Box<dyn Builtin>),
-            ("substitute", Box::new(PrimitiveSubstitute) as Box<dyn Builtin>),
-            ("sum", Box::new(PrimitiveSum) as Box<dyn Builtin>),
-            // builtins end
-        ])
-    };
-}
+pub static BUILTIN: LazyLock<HashMap<&'static str, Box<dyn Builtin>>> = LazyLock::new(|| {
+    HashMap::from([
+        // automatically populated on build. see build.rs // builtins start
+        ("<-", Box::new(InfixAssign) as Box<dyn Builtin>),
+        ("+", Box::new(InfixAdd) as Box<dyn Builtin>),
+        ("-", Box::new(InfixSub) as Box<dyn Builtin>),
+        ("-", Box::new(PrefixSub) as Box<dyn Builtin>),
+        ("!", Box::new(PrefixNot) as Box<dyn Builtin>),
+        ("..", Box::new(PrefixPack) as Box<dyn Builtin>),
+        ("*", Box::new(InfixMul) as Box<dyn Builtin>),
+        ("/", Box::new(InfixDiv) as Box<dyn Builtin>),
+        ("^", Box::new(InfixPow) as Box<dyn Builtin>),
+        ("%", Box::new(InfixMod) as Box<dyn Builtin>),
+        ("||", Box::new(InfixOr) as Box<dyn Builtin>),
+        ("&&", Box::new(InfixAnd) as Box<dyn Builtin>),
+        ("|", Box::new(InfixVectorOr) as Box<dyn Builtin>),
+        ("&", Box::new(InfixVectorAnd) as Box<dyn Builtin>),
+        (">", Box::new(InfixGreater) as Box<dyn Builtin>),
+        (">=", Box::new(InfixGreaterEqual) as Box<dyn Builtin>),
+        ("<", Box::new(InfixLess) as Box<dyn Builtin>),
+        ("<=", Box::new(InfixLessEqual) as Box<dyn Builtin>),
+        ("==", Box::new(InfixEqual) as Box<dyn Builtin>),
+        ("!=", Box::new(InfixNotEqual) as Box<dyn Builtin>),
+        ("|>", Box::new(InfixPipe) as Box<dyn Builtin>),
+        (":", Box::new(InfixColon) as Box<dyn Builtin>),
+        ("$", Box::new(InfixDollar) as Box<dyn Builtin>),
+        ("..", Box::new(PostfixPack) as Box<dyn Builtin>),
+        ("[[", Box::new(PostfixIndex) as Box<dyn Builtin>),
+        ("[", Box::new(PostfixVecIndex) as Box<dyn Builtin>),
+        ("c", Box::new(PrimitiveC) as Box<dyn Builtin>),
+        ("callstack", Box::new(PrimitiveCallstack) as Box<dyn Builtin>),
+        ("environment", Box::new(PrimitiveEnvironment) as Box<dyn Builtin>),
+        ("eval", Box::new(PrimitiveEval) as Box<dyn Builtin>),
+        ("length", Box::new(PrimitiveLength) as Box<dyn Builtin>),
+        ("list", Box::new(PrimitiveList) as Box<dyn Builtin>),
+        ("names", Box::new(PrimitiveNames) as Box<dyn Builtin>),
+        ("parent", Box::new(PrimitiveParent) as Box<dyn Builtin>),
+        ("paste", Box::new(PrimitivePaste) as Box<dyn Builtin>),
+        ("print", Box::new(PrimitivePrint) as Box<dyn Builtin>),
+        ("q", Box::new(PrimitiveQ) as Box<dyn Builtin>),
+        ("quote", Box::new(PrimitiveQuote) as Box<dyn Builtin>),
+        ("rnorm", Box::new(PrimitiveRnorm) as Box<dyn Builtin>),
+        ("runif", Box::new(PrimitiveRunif) as Box<dyn Builtin>),
+        ("substitute", Box::new(PrimitiveSubstitute) as Box<dyn Builtin>),
+        ("sum", Box::new(PrimitiveSum) as Box<dyn Builtin>),
+        // builtins end
+    ])
+});

--- a/src/callable/core.rs
+++ b/src/callable/core.rs
@@ -1,10 +1,8 @@
 extern crate r_derive;
 
-use crate::callable::builtins::BUILTIN;
 use crate::callable::dyncompare::*;
 use crate::cli::Experiment;
 use crate::context::Context;
-use crate::error::Error;
 use crate::object::List;
 use crate::object::{Expr, ExprList, Obj};
 use crate::{internal_err, lang::*};
@@ -202,7 +200,7 @@ pub trait Format {
     }
 }
 
-pub trait Builtin: Callable + CallableClone + Format + DynCompare + Sync {
+pub trait Builtin: Callable + CallableClone + Format + DynCompare + Sync + Send {
     fn is_transparent(&self) -> bool {
         false
     }
@@ -277,18 +275,6 @@ where
 
 impl CallableFormals for String {}
 impl Builtin for String {}
-
-pub fn builtin(s: &str) -> Result<Box<dyn Builtin>, Signal> {
-    let err = Error::VariableNotFound(s.to_string());
-    <Box<dyn Builtin>>::try_from(s).or(Err(err.into()))
-}
-
-impl TryFrom<&str> for Box<dyn Builtin> {
-    type Error = ();
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        BUILTIN.get(s).map_or(Err(()), |b| Ok(b.clone()))
-    }
-}
 
 pub fn force_promises(
     vals: List,

--- a/src/callable/keywords.rs
+++ b/src/callable/keywords.rs
@@ -21,6 +21,8 @@ impl Format for KeywordReturn {
     }
 }
 
+impl CallableFormals for KeywordReturn {}
+
 impl Callable for KeywordReturn {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut args = args.values.into_iter();
@@ -50,6 +52,8 @@ impl Format for KeywordIf {
     }
 }
 
+impl CallableFormals for KeywordIf {}
+
 impl Callable for KeywordIf {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut args = args.values.into_iter();
@@ -69,6 +73,8 @@ impl Callable for KeywordIf {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin]
 pub struct KeywordFor;
+
+impl CallableFormals for KeywordFor {}
 
 impl Format for KeywordFor {
     fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
@@ -126,6 +132,8 @@ impl Callable for KeywordFor {
 #[builtin]
 pub struct KeywordWhile;
 
+impl CallableFormals for KeywordWhile {}
+
 impl Format for KeywordWhile {
     fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
         format!("while ({}) {}", args.values[0], args.values[1])
@@ -181,6 +189,8 @@ impl Format for KeywordRepeat {
     }
 }
 
+impl CallableFormals for KeywordRepeat {}
+
 impl Callable for KeywordRepeat {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut args = args.values.into_iter();
@@ -213,6 +223,8 @@ impl Callable for KeywordRepeat {
 #[builtin]
 pub struct KeywordParen;
 
+impl CallableFormals for KeywordParen {}
+
 impl Format for KeywordParen {
     fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
         format!("({})", args.values.first().unwrap())
@@ -233,6 +245,8 @@ impl Callable for KeywordParen {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin]
 pub struct KeywordBlock;
+
+impl CallableFormals for KeywordBlock {}
 
 impl Format for KeywordBlock {
     fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
@@ -264,6 +278,44 @@ impl Callable for KeywordBlock {
         }
 
         Ok(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[builtin]
+pub struct KeywordVec;
+
+impl Format for KeywordVec {
+    fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
+        format!("[{}]", args)
+    }
+}
+
+impl CallableFormals for KeywordVec {}
+
+impl Callable for KeywordVec {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        // for now just use c()
+        super::primitive::PrimitiveC.call(args, stack)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[builtin]
+pub struct KeywordList;
+
+impl Format for KeywordList {
+    fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
+        let trailing_comma = if args.len() > 1 { "" } else { "," };
+        format!("({}{})", args, trailing_comma)
+    }
+}
+
+impl CallableFormals for KeywordList {}
+
+impl Callable for KeywordList {
+    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
+        super::primitive::PrimitiveList.call(args, stack)
     }
 }
 

--- a/src/callable/operators.rs
+++ b/src/callable/operators.rs
@@ -10,6 +10,7 @@ use crate::object::*;
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "<-", kind = Infix)]
 pub struct InfixAssign;
+impl CallableFormals for InfixAssign {}
 impl Callable for InfixAssign {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = args.unnamed_binary_args();
@@ -20,6 +21,7 @@ impl Callable for InfixAssign {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "+", kind = Infix)]
 pub struct InfixAdd;
+impl CallableFormals for InfixAdd {}
 impl Callable for InfixAdd {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -30,6 +32,7 @@ impl Callable for InfixAdd {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "-", kind = Infix)]
 pub struct InfixSub;
+impl CallableFormals for InfixSub {}
 impl Callable for InfixSub {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -40,6 +43,7 @@ impl Callable for InfixSub {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "-", kind = Prefix)]
 pub struct PrefixSub;
+impl CallableFormals for PrefixSub {}
 impl Callable for PrefixSub {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let what = stack.eval(args.unnamed_unary_arg())?;
@@ -50,6 +54,7 @@ impl Callable for PrefixSub {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "!", kind = Prefix)]
 pub struct PrefixNot;
+impl CallableFormals for PrefixNot {}
 impl Callable for PrefixNot {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let what = stack.eval(args.unnamed_unary_arg())?;
@@ -60,6 +65,7 @@ impl Callable for PrefixNot {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "..", kind = Prefix)]
 pub struct PrefixPack;
+impl CallableFormals for PrefixPack {}
 impl Callable for PrefixPack {
     fn call(&self, _args: ExprList, _stack: &mut CallStack) -> EvalResult {
         Error::IncorrectContext("..".to_string()).into()
@@ -69,6 +75,7 @@ impl Callable for PrefixPack {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "*", kind = Infix)]
 pub struct InfixMul;
+impl CallableFormals for InfixMul {}
 impl Callable for InfixMul {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -79,6 +86,7 @@ impl Callable for InfixMul {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "/", kind = Infix)]
 pub struct InfixDiv;
+impl CallableFormals for InfixDiv {}
 impl Callable for InfixDiv {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -89,6 +97,7 @@ impl Callable for InfixDiv {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "^")]
 pub struct InfixPow;
+impl CallableFormals for InfixPow {}
 impl Callable for InfixPow {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -99,6 +108,7 @@ impl Callable for InfixPow {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "%", kind = Infix)]
 pub struct InfixMod;
+impl CallableFormals for InfixMod {}
 impl Callable for InfixMod {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -109,6 +119,7 @@ impl Callable for InfixMod {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "||", kind = Infix)]
 pub struct InfixOr;
+impl CallableFormals for InfixOr {}
 impl Callable for InfixOr {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -128,6 +139,7 @@ impl Callable for InfixOr {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "&&", kind = Infix)]
 pub struct InfixAnd;
+impl CallableFormals for InfixAnd {}
 impl Callable for InfixAnd {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -147,6 +159,7 @@ impl Callable for InfixAnd {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "|", kind = Infix)]
 pub struct InfixVectorOr;
+impl CallableFormals for InfixVectorOr {}
 impl Callable for InfixVectorOr {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -157,6 +170,7 @@ impl Callable for InfixVectorOr {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "&", kind = Infix)]
 pub struct InfixVectorAnd;
+impl CallableFormals for InfixVectorAnd {}
 impl Callable for InfixVectorAnd {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -167,6 +181,7 @@ impl Callable for InfixVectorAnd {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = ">", kind = Infix)]
 pub struct InfixGreater;
+impl CallableFormals for InfixGreater {}
 impl Callable for InfixGreater {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -177,6 +192,7 @@ impl Callable for InfixGreater {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = ">=", kind = Infix)]
 pub struct InfixGreaterEqual;
+impl CallableFormals for InfixGreaterEqual {}
 impl Callable for InfixGreaterEqual {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -187,6 +203,7 @@ impl Callable for InfixGreaterEqual {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "<", kind = Infix)]
 pub struct InfixLess;
+impl CallableFormals for InfixLess {}
 impl Callable for InfixLess {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -197,6 +214,7 @@ impl Callable for InfixLess {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "<=", kind = Infix)]
 pub struct InfixLessEqual;
+impl CallableFormals for InfixLessEqual {}
 impl Callable for InfixLessEqual {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -207,6 +225,7 @@ impl Callable for InfixLessEqual {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "==", kind = Infix)]
 pub struct InfixEqual;
+impl CallableFormals for InfixEqual {}
 impl Callable for InfixEqual {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -217,6 +236,7 @@ impl Callable for InfixEqual {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "!=", kind = Infix)]
 pub struct InfixNotEqual;
+impl CallableFormals for InfixNotEqual {}
 impl Callable for InfixNotEqual {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (lhs, rhs) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -227,6 +247,7 @@ impl Callable for InfixNotEqual {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "|>", kind = Infix)]
 pub struct InfixPipe;
+impl CallableFormals for InfixPipe {}
 impl Callable for InfixPipe {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         // TODO: reduce call stack nesting here
@@ -252,6 +273,7 @@ impl Callable for InfixPipe {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = ":", kind = Infix)]
 pub struct InfixColon;
+impl CallableFormals for InfixColon {}
 impl Callable for InfixColon {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut argstream = args.into_iter();
@@ -324,6 +346,7 @@ impl Callable for InfixColon {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "$", kind = Infix)]
 pub struct InfixDollar;
+impl CallableFormals for InfixDollar {}
 impl Callable for InfixDollar {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let mut argstream = args.into_iter();
@@ -390,6 +413,7 @@ impl Callable for InfixDollar {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "..", kind = Postfix)]
 pub struct PostfixPack;
+impl CallableFormals for PostfixPack {}
 impl Callable for PostfixPack {
     fn call(&self, _args: ExprList, _stack: &mut CallStack) -> EvalResult {
         Error::IncorrectContext("..".to_string()).into()
@@ -399,6 +423,7 @@ impl Callable for PostfixPack {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "[[", kind = PostfixCall("[[", "]]"))]
 pub struct PostfixIndex;
+impl CallableFormals for PostfixIndex {}
 impl Callable for PostfixIndex {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (what, index) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -416,6 +441,7 @@ impl Callable for PostfixIndex {
 #[derive(Debug, Clone, PartialEq)]
 #[builtin(sym = "[", kind = PostfixCall("[", "]"))]
 pub struct PostfixVecIndex;
+impl CallableFormals for PostfixVecIndex {}
 impl Callable for PostfixVecIndex {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (what, index) = stack.eval_binary(args.unnamed_binary_args())?;
@@ -427,40 +453,6 @@ impl Callable for PostfixVecIndex {
         let what = stack.eval_mut(x.0)?;
         let index = stack.eval(x.1)?;
         what.try_get(index)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-#[builtin]
-pub struct PrimVec;
-
-impl Format for PrimVec {
-    fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
-        format!("[{}]", args)
-    }
-}
-
-impl Callable for PrimVec {
-    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
-        // for now just use c()
-        super::primitive::PrimitiveC.call(args, stack)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-#[builtin]
-pub struct PrimList;
-
-impl Format for PrimList {
-    fn rfmt_call_with(&self, _state: FormatState, args: &ExprList) -> String {
-        let trailing_comma = if args.len() > 1 { "" } else { "," };
-        format!("({}{})", args, trailing_comma)
-    }
-}
-
-impl Callable for PrimList {
-    fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
-        super::primitive::PrimitiveList.call(args, stack)
     }
 }
 

--- a/src/callable/primitive/c.rs
+++ b/src/callable/primitive/c.rs
@@ -2,9 +2,9 @@ use r_derive::*;
 
 use crate::callable::core::*;
 use crate::context::Context;
-use crate::lang::*;
 use crate::object::types::*;
 use crate::object::*;
+use crate::{formals, lang::*};
 
 /// Concatenate Values
 ///
@@ -41,6 +41,9 @@ use crate::object::*;
 #[builtin(sym = "c")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveC;
+
+formals!(PrimitiveC, "(...)");
+
 impl Callable for PrimitiveC {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         // this can be cleaned up quite a bit, but I just need it working with

--- a/src/callable/primitive/callstack.rs
+++ b/src/callable/primitive/callstack.rs
@@ -2,7 +2,7 @@ use r_derive::builtin;
 
 use crate::callable::core::*;
 use crate::lang::{CallStack, EvalResult};
-use crate::object::*;
+use crate::{formals, object::*};
 
 /// Get the Current Call Stack
 ///
@@ -33,6 +33,9 @@ use crate::object::*;
 #[builtin(sym = "callstack")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveCallstack;
+
+formals!(PrimitiveCallstack, "()");
+
 impl Callable for PrimitiveCallstack {
     fn call(&self, _args: ExprList, stack: &mut CallStack) -> EvalResult {
         Ok(Obj::List(List::from(

--- a/src/callable/primitive/environment.rs
+++ b/src/callable/primitive/environment.rs
@@ -3,6 +3,7 @@ use r_derive::*;
 use crate::callable::core::*;
 use crate::context::Context;
 use crate::error::Error;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
 
@@ -41,11 +42,10 @@ use crate::object::*;
 #[builtin(sym = "environment")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveEnvironment;
-impl Callable for PrimitiveEnvironment {
-    fn formals(&self) -> ExprList {
-        ExprList::from(vec![(Some(String::from("fun")), Expr::Missing)])
-    }
 
+formals!(PrimitiveEnvironment, "(fun,)");
+
+impl Callable for PrimitiveEnvironment {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (vals, _) = self.match_arg_exprs(args, stack)?;
         let mut vals = Obj::List(vals);

--- a/src/callable/primitive/eval.rs
+++ b/src/callable/primitive/eval.rs
@@ -1,24 +1,11 @@
-use lazy_static::lazy_static;
 use r_derive::*;
 
 use crate::callable::core::*;
 use crate::context::Context;
 use crate::error::Error;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
-
-lazy_static! {
-    pub static ref FORMALS: ExprList = ExprList::from(vec![
-        (Some("x".to_string()), Expr::Missing),
-        (
-            Some("envir".to_string()),
-            Expr::Call(
-                Box::new(Expr::Symbol("environment".to_string())),
-                ExprList::new()
-            )
-        )
-    ]);
-}
 
 /// Evaluate Code in an Environment
 ///
@@ -58,11 +45,10 @@ lazy_static! {
 #[builtin(sym = "eval")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveEval;
-impl Callable for PrimitiveEval {
-    fn formals(&self) -> ExprList {
-        FORMALS.clone()
-    }
 
+formals!(PrimitiveEval, "(x, envir = environment())");
+
+impl Callable for PrimitiveEval {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (args, _ellipsis) = self.match_arg_exprs(args, stack)?;
         let mut args = Obj::List(args);

--- a/src/callable/primitive/length.rs
+++ b/src/callable/primitive/length.rs
@@ -2,6 +2,7 @@ use r_derive::*;
 
 use crate::callable::core::*;
 use crate::error::Error;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
 
@@ -32,10 +33,9 @@ use crate::object::*;
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveLength;
 
+formals!(PrimitiveLength, "(x,)");
+
 impl Callable for PrimitiveLength {
-    fn formals(&self) -> ExprList {
-        ExprList::from(vec![(Some("x".to_string()), Expr::Missing)])
-    }
     fn call_matched(&self, args: List, _ellipsis: List, stack: &mut CallStack) -> EvalResult {
         let mut args = Obj::List(args);
         let x = args.try_get_named("x")?.force(stack)?;

--- a/src/callable/primitive/list.rs
+++ b/src/callable/primitive/list.rs
@@ -2,6 +2,7 @@ use r_derive::*;
 
 use crate::callable::core::*;
 use crate::context::Context;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
 
@@ -49,6 +50,9 @@ use crate::object::*;
 #[builtin(sym = "list")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveList;
+
+formals!(PrimitiveList, "(...)");
+
 impl Callable for PrimitiveList {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         stack.eval_list_eager(args)

--- a/src/callable/primitive/names.rs
+++ b/src/callable/primitive/names.rs
@@ -1,6 +1,7 @@
 use r_derive::*;
 
 use crate::callable::core::*;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
 
@@ -51,11 +52,10 @@ use crate::object::*;
 #[builtin(sym = "names")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveNames;
-impl Callable for PrimitiveNames {
-    fn formals(&self) -> ExprList {
-        ExprList::from(vec![(Some(String::from("x")), Expr::Missing)])
-    }
 
+formals!(PrimitiveNames, "(x,)");
+
+impl Callable for PrimitiveNames {
     fn call_matched(&self, args: List, mut _ellipsis: List, stack: &mut CallStack) -> EvalResult {
         let x = Obj::List(args).try_get_named("x")?.force(stack)?;
 

--- a/src/callable/primitive/parent.rs
+++ b/src/callable/primitive/parent.rs
@@ -2,6 +2,7 @@ use r_derive::*;
 
 use crate::callable::core::*;
 use crate::context::Context;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
 
@@ -30,11 +31,10 @@ use crate::object::*;
 #[builtin(sym = "parent")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveParent;
-impl Callable for PrimitiveParent {
-    fn formals(&self) -> ExprList {
-        ExprList::from(vec![(Some(String::from("x")), Expr::Missing)])
-    }
 
+formals!(PrimitiveParent, "(x,)");
+
+impl Callable for PrimitiveParent {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (vals, _) = self.match_arg_exprs(args, stack)?;
         let mut vals = Obj::List(vals);

--- a/src/callable/primitive/paste.rs
+++ b/src/callable/primitive/paste.rs
@@ -1,9 +1,9 @@
-use r_derive::*;
-
 use crate::callable::core::*;
 use crate::error::*;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
+use r_derive::*;
 
 /// Paste Objects into Strings
 ///
@@ -44,15 +44,10 @@ use crate::object::*;
 #[builtin(sym = "paste")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitivePaste;
-impl Callable for PrimitivePaste {
-    fn formals(&self) -> ExprList {
-        ExprList::from(vec![
-            (None, Expr::Ellipsis(None)),
-            (Some(String::from("sep")), Expr::String(" ".to_string())),
-            (Some(String::from("collapse")), Expr::Null),
-        ])
-    }
 
+formals!(PrimitivePaste, "(..., sep = ' ', collapse = null)");
+
+impl Callable for PrimitivePaste {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (args, ellipsis) = self.match_arg_exprs(args, stack)?;
 

--- a/src/callable/primitive/print.rs
+++ b/src/callable/primitive/print.rs
@@ -1,17 +1,10 @@
-use lazy_static::lazy_static;
 use r_derive::*;
 use std::io::Write;
 
 use crate::callable::core::*;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
-
-lazy_static! {
-    pub static ref FORMALS: ExprList = ExprList::from(vec![
-        (Some("x".to_string()), Expr::Missing),
-        (None, Expr::Ellipsis(None))
-    ]);
-}
 
 /// Print to the Console
 ///
@@ -20,7 +13,7 @@ lazy_static! {
 /// ## Usage
 ///
 /// ```custom,{class=r}
-/// print(x)
+/// print(x, ...)
 /// ```
 ///
 /// ## Arguments
@@ -37,11 +30,10 @@ lazy_static! {
 #[builtin(sym = "print")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitivePrint;
-impl Callable for PrimitivePrint {
-    fn formals(&self) -> ExprList {
-        FORMALS.clone()
-    }
 
+formals!(PrimitivePrint, "(x, ...)");
+
+impl Callable for PrimitivePrint {
     fn call_matched(&self, args: List, _ellipsis: List, stack: &mut CallStack) -> EvalResult {
         let mut args = Obj::List(args);
         let x = args.try_get_named("x")?.force(stack)?;

--- a/src/callable/primitive/q.rs
+++ b/src/callable/primitive/q.rs
@@ -1,8 +1,8 @@
 use r_derive::*;
 
 use crate::callable::core::*;
-use crate::lang::*;
 use crate::object::ExprList;
+use crate::{formals, lang::*};
 
 /// Quit
 ///
@@ -30,6 +30,9 @@ use crate::object::ExprList;
 #[builtin(sym = "q")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveQ;
+
+formals!(PrimitiveQ, "()");
+
 impl Callable for PrimitiveQ {
     fn call(&self, _args: ExprList, _stack: &mut CallStack) -> EvalResult {
         Err(Signal::Condition(Cond::Terminate))

--- a/src/callable/primitive/quote.rs
+++ b/src/callable/primitive/quote.rs
@@ -1,6 +1,7 @@
 use r_derive::*;
 
 use crate::callable::core::*;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
 
@@ -30,6 +31,9 @@ use crate::object::*;
 #[builtin(sym = "quote")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveQuote;
+
+formals!(PrimitiveQuote, "(x)");
+
 impl Callable for PrimitiveQuote {
     fn call(&self, args: ExprList, _stack: &mut CallStack) -> EvalResult {
         Ok(Obj::Expr(args.get(0).unwrap_or(Expr::Null)))

--- a/src/callable/primitive/rnorm.rs
+++ b/src/callable/primitive/rnorm.rs
@@ -3,6 +3,7 @@ use rand_distr::{Distribution, Normal};
 
 use crate::callable::core::*;
 use crate::error::Error;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
 
@@ -41,15 +42,10 @@ use crate::object::*;
 #[builtin(sym = "rnorm")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveRnorm;
-impl Callable for PrimitiveRnorm {
-    fn formals(&self) -> ExprList {
-        ExprList::from(vec![
-            (Some(String::from("n")), Expr::Number(1.0)),
-            (Some(String::from("mean")), Expr::Number(0.0)),
-            (Some(String::from("std")), Expr::Number(1.0)),
-        ])
-    }
 
+formals!(PrimitiveRnorm, "(n = 1, mean = 0, std = 1)");
+
+impl Callable for PrimitiveRnorm {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         use Error::ArgumentInvalid;
         let (vals, _) = self.match_arg_exprs(args, stack)?;

--- a/src/callable/primitive/runif.rs
+++ b/src/callable/primitive/runif.rs
@@ -4,6 +4,7 @@ use rand::Rng;
 
 use crate::callable::core::*;
 use crate::error::Error;
+use crate::formals;
 use crate::lang::*;
 use crate::object::*;
 
@@ -42,15 +43,10 @@ use crate::object::*;
 #[builtin(sym = "runif")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveRunif;
-impl Callable for PrimitiveRunif {
-    fn formals(&self) -> ExprList {
-        ExprList::from(vec![
-            (Some(String::from("n")), Expr::Number(1.0)),
-            (Some(String::from("min")), Expr::Number(0.0)),
-            (Some(String::from("max")), Expr::Number(1.0)),
-        ])
-    }
 
+formals!(PrimitiveRunif, "(n = 1, min = 0, max = 1)");
+
+impl Callable for PrimitiveRunif {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         use Error::ArgumentInvalid;
 

--- a/src/callable/primitive/substitute.rs
+++ b/src/callable/primitive/substitute.rs
@@ -1,25 +1,12 @@
-use lazy_static::lazy_static;
 use r_derive::*;
 
 use crate::callable::core::*;
 use crate::callable::keywords::KeywordParen;
 use crate::context::Context;
+use crate::formals;
 use crate::internal_err;
 use crate::lang::*;
 use crate::object::*;
-
-lazy_static! {
-    pub static ref FORMALS: ExprList = ExprList::from(vec![
-        (Some("expr".to_string()), Expr::Missing),
-        (
-            Some("envir".to_string()),
-            Expr::Call(
-                Box::new(Expr::Symbol("environment".to_string())),
-                ExprList::new()
-            )
-        )
-    ]);
-}
 
 /// Substitute Expressions
 ///
@@ -55,11 +42,10 @@ lazy_static! {
 #[builtin(sym = "substitute")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveSubstitute;
-impl Callable for PrimitiveSubstitute {
-    fn formals(&self) -> ExprList {
-        FORMALS.clone()
-    }
 
+formals!(PrimitiveSubstitute, "(expr, envir = environment())");
+
+impl Callable for PrimitiveSubstitute {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         use Expr::*;
         let (args, _ellipsis) = self.match_arg_exprs(args, stack)?;

--- a/src/callable/primitive/sum.rs
+++ b/src/callable/primitive/sum.rs
@@ -2,6 +2,7 @@ use r_derive::*;
 
 use crate::callable::core::*;
 use crate::error::*;
+use crate::formals;
 use crate::internal_err;
 use crate::lang::*;
 use crate::object::reptype::RepType;
@@ -32,11 +33,9 @@ use crate::object::*;
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveSum;
 
-impl Callable for PrimitiveSum {
-    fn formals(&self) -> ExprList {
-        ExprList::from(vec![(None, Expr::Ellipsis(None))])
-    }
+formals!(PrimitiveSum, "(...)");
 
+impl Callable for PrimitiveSum {
     fn call(&self, args: ExprList, stack: &mut CallStack) -> EvalResult {
         let (_, ellipsis) = self.match_arg_exprs(args, stack)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,15 +30,16 @@ pub enum Error {
     CannotBeCoercedTo(&'static str),
     InvalidRange,
 
+    // destructuring
+    CannotBeDestructuredIntoList,
+
     // function parsing
     InvalidFunctionParameter(Expr),
     DuplicatedParameter(String),
     DuplicatedMoreParameter(),
-
     Missing,
     ArgumentMissing(String),
     ArgumentInvalid(String),
-    Other(String),
 
     // parsing errors
     ParseFailureVerbose(pest::error::Error<en::Rule>),
@@ -55,6 +56,8 @@ pub enum Error {
 
     // features
     FeatureDisabledRestArgs,
+
+    Other(String),
 }
 
 impl Error {
@@ -116,6 +119,7 @@ impl Error {
             Error::InvalidFunctionParameter(expr) => format!("invalid function parameter: {}", expr),
             Error::DuplicatedParameter(name) => format!("duplicated parameter name: {}", name),
             Error::DuplicatedMoreParameter() => "duplicated '..<more>' parameters".to_string(),
+            Error::CannotBeDestructuredIntoList => "object cannot be coerced into a list for destructuring".to_string(),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -132,10 +132,7 @@ impl Error {
         use pest::error::InputLocation;
         use pest::{Position, Span};
         let variant = match error.variant {
-            ParsingError {
-                positives: p,
-                negatives: n,
-            } => ParsingError {
+            ParsingError { positives: p, negatives: n } => ParsingError {
                 positives: p.into_iter().map(|i| i.into()).collect(),
                 negatives: n.into_iter().map(|i| i.into()).collect(),
             },

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -69,11 +69,7 @@ impl ViewMut for Obj {
                 Vector::Logical(v) => Vector::Logical(v.view_mut()),
             }),
 
-            Obj::List(List {
-                names,
-                values,
-                subsets,
-            }) => Obj::List(List {
+            Obj::List(List { names, values, subsets }) => Obj::List(List {
                 names: (*names).view_mut(),
                 values: (*values).view_mut(),
                 subsets: (*subsets).clone(),
@@ -709,10 +705,7 @@ impl CallStack {
     }
 
     pub fn add_child_frame(&mut self, call: Expr, env: Rc<Environment>) -> usize {
-        let local_env = Rc::new(Environment {
-            parent: Some(env.clone()),
-            ..Default::default()
-        });
+        let local_env = Rc::new(Environment { parent: Some(env.clone()), ..Default::default() });
 
         self.add_frame(call, local_env)
     }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,4 +1,5 @@
-use crate::callable::core::{builtin, Callable};
+use crate::callable::builtins::BUILTIN;
+use crate::callable::core::Callable;
 use crate::cli::Experiment;
 use crate::context::Context;
 use crate::error::*;
@@ -689,9 +690,9 @@ impl CallStack {
             };
         }
 
-        if let Ok(prim) = builtin(name.as_str()) {
+        if let Some(prim) = BUILTIN.get(name.as_str()) {
             Result::Ok((
-                Obj::Function(ExprList::new(), Expr::Primitive(prim), self.env()),
+                Obj::Function(ExprList::new(), Expr::Primitive(prim.clone()), self.env()),
                 env,
             ))
         } else {
@@ -943,8 +944,10 @@ fn eval_call(callstack: &mut CallStack, expr: Expr, mutable: bool) -> EvalResult
             };
             callstack.pop_frame_and_return(result)
         }
-        Expr::String(name) | Expr::Symbol(name) if builtin(&name).is_ok() => {
-            let f = builtin(&name)?;
+        Expr::String(name) | Expr::Symbol(name) if BUILTIN.contains_key(name.as_str()) => {
+            let f = BUILTIN
+                .get(name.as_str())
+                .ok_or(Error::VariableNotFound(name))?;
             callstack.add_frame(expr, callstack.last_frame().env().clone());
             let result = if mutable {
                 f.call_mut(args, callstack)

--- a/src/object/ast.rs
+++ b/src/object/ast.rs
@@ -151,18 +151,13 @@ impl FromIterator<Expr> for ExprList {
         T: IntoIterator<Item = Expr>,
     {
         let values: Vec<Expr> = iter.into_iter().collect();
-        ExprList {
-            keys: vec![None; values.len()],
-            values,
-        }
+        ExprList { keys: vec![None; values.len()], values }
     }
 }
 
 impl ExprList {
     pub fn new() -> ExprList {
-        ExprList {
-            ..Default::default()
-        }
+        ExprList { ..Default::default() }
     }
 
     pub fn get_named(&self, key: &String) -> Option<Expr> {
@@ -220,10 +215,7 @@ impl ExprList {
             let keys_trailing = self.keys.drain(index..self.keys.len()).collect();
             let vals_trailing = self.values.drain(index..self.values.len()).collect();
 
-            ExprList {
-                keys: keys_trailing,
-                values: vals_trailing,
-            }
+            ExprList { keys: keys_trailing, values: vals_trailing }
         } else {
             ExprList::new()
         }
@@ -328,19 +320,13 @@ impl ExprList {
 
 impl From<Vec<Expr>> for ExprList {
     fn from(values: Vec<Expr>) -> Self {
-        ExprList {
-            keys: vec![None; values.len()],
-            values,
-        }
+        ExprList { keys: vec![None; values.len()], values }
     }
 }
 
 impl From<Expr> for ExprList {
     fn from(value: Expr) -> Self {
-        ExprList {
-            keys: vec![None],
-            values: vec![value],
-        }
+        ExprList { keys: vec![None], values: vec![value] }
     }
 }
 

--- a/src/object/environment.rs
+++ b/src/object/environment.rs
@@ -90,10 +90,10 @@ impl Environment {
                 continue;
 
             // if we're at the top level, fall back to primitives if available
-            } else if let Ok(prim) = name.as_str().try_into() {
+            } else if let Some(prim) = BUILTIN.get(name.as_str()) {
                 let x = Obj::Function(
                     ExprList::new(),
-                    Expr::Primitive(prim),
+                    Expr::Primitive(prim.clone()),
                     Rc::new(self.clone()), // TODO(bug): will this retain shared ref?
                 );
 

--- a/src/object/list.rs
+++ b/src/object/list.rs
@@ -16,10 +16,7 @@ pub struct List {
 
 impl From<Vec<(Option<String>, Obj)>> for List {
     fn from(value: Vec<(Option<String>, Obj)>) -> Self {
-        let mut result = List {
-            values: CowObj::from(value),
-            ..Default::default()
-        };
+        let mut result = List { values: CowObj::from(value), ..Default::default() };
 
         result.reindex();
         result

--- a/src/object/vector/subsets.rs
+++ b/src/object/vector/subsets.rs
@@ -41,10 +41,7 @@ impl Subsets {
     }
 
     pub fn bind_names(self, names: CowObj<HashMap<String, Vec<usize>>>) -> NamedSubsets {
-        NamedSubsets {
-            subsets: self,
-            names,
-        }
+        NamedSubsets { subsets: self, names }
     }
 }
 

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -519,7 +519,7 @@ where
     R: RuleType + Into<en::Rule>,
 {
     let args = parse_list_elements(config, parser, pratt, pair)?;
-    Ok(Expr::new_primitive_call(PrimVec, args))
+    Ok(Expr::new_primitive_call(KeywordVec, args))
 }
 
 fn parse_list<P, R>(
@@ -533,7 +533,7 @@ where
     R: RuleType + Into<en::Rule>,
 {
     let args = parse_list_elements(config, parser, pratt, pair)?;
-    Ok(Expr::new_primitive_call(PrimList, args))
+    Ok(Expr::new_primitive_call(KeywordList, args))
 }
 
 #[cfg(test)]

--- a/src/repl/headless.rs
+++ b/src/repl/headless.rs
@@ -98,22 +98,12 @@ pub fn wasm_parse_errors(args: JsValue, input: &str) -> Vec<ParseError> {
 
     match res {
         Ok(_) => vec![],
-        Err(Signal::Error(ParseUnexpected(r, (start, end)))) => vec![ParseError {
-            start,
-            end,
-            message: format!("Unexpected {r:?}"),
-        }],
+        Err(Signal::Error(ParseUnexpected(r, (start, end)))) => {
+            vec![ParseError { start, end, message: format!("Unexpected {r:?}") }]
+        }
         Err(Signal::Error(ParseFailure(e))) => match e.location {
-            Pos(p) => vec![ParseError {
-                start: p,
-                end: p,
-                message: format!("{e:?}"),
-            }],
-            Span((start, end)) => vec![ParseError {
-                start,
-                end,
-                message: format!("{e:?}"),
-            }],
+            Pos(p) => vec![ParseError { start: p, end: p, message: format!("{e:?}") }],
+            Span((start, end)) => vec![ParseError { start, end, message: format!("{e:?}") }],
         },
         Err(e) => {
             log(&format!("{e:?}"));

--- a/src/repl/release.rs
+++ b/src/repl/release.rs
@@ -1,26 +1,28 @@
-use crate::{cli::Experiment, parser::Localization, session::Session};
+use crate::cli::Experiment;
+use crate::parser::Localization;
+use crate::session::Session;
+use std::sync::LazyLock;
 use strum::IntoEnumIterator;
 
 pub const RELEASE_NAME: &str = "Beautiful You";
-
 pub const GIT_HASH: &str = env!("GIT_HASH");
 pub const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 pub const YEAR: &str = "2024";
 
-pub const COPYRIGHT_LONG_INST: &str = "--warranty";
-lazy_static::lazy_static! {
-    static ref COPYRIGHT: String = format!(
-"Copyright (C) {YEAR} R Authors
+pub const COPYRIGHT_LONG_FLAG: &str = "--warranty";
+static COPYRIGHT: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "Copyright (C) {YEAR} R Authors
   
 This program comes with ABSOLUTELY NO WARRANTY. This is free software, 
 and you are welcome to redistribute it under certain conditions. For more
-information, restart with `{COPYRIGHT_LONG_INST}`.");
-}
+information, restart with `{COPYRIGHT_LONG_FLAG}`."
+    )
+});
 
-lazy_static::lazy_static! {
-    static ref COPYRIGHT_LONG: String = format!(
-"Copyright (C) {YEAR} R Authors
+static COPYRIGHT_LONG: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "Copyright (C) {YEAR} R Authors
   
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -33,8 +35,9 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.  
   
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.");
-}
+along with this program. If not, see <https://www.gnu.org/licenses/>."
+    )
+});
 
 pub const AVAILABLE_FUNCTIONS: &str =
     "\nSee a list of implemented functions using `names(parent())`\n";

--- a/src/session.rs
+++ b/src/session.rs
@@ -26,10 +26,7 @@ pub struct SessionParserConfig {
 
 impl From<Session> for SessionParserConfig {
     fn from(val: Session) -> Self {
-        SessionParserConfig {
-            locale: val.locale,
-            experiments: val.experiments,
-        }
+        SessionParserConfig { locale: val.locale, experiments: val.experiments }
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,18 +11,17 @@ impl<T, U> SameType<T> for U {
 }
 
 #[macro_export]
-macro_rules! r {
+macro_rules! r_macro_stringify {
     // evaluate a single token directly
     {{ $expr:literal }} => {{
         {
             // test if token is a string literal and evaluate directly
             if let Some(s) = (&$expr as &dyn std::any::Any).downcast_ref::<&str>() {
-                $crate::lang::CallStack::default().parse_and_eval(s)
+                s
 
             // otherwise stringify token before evaluating
             } else {
-                let expr = stringify!($expr);
-                $crate::lang::CallStack::default().parse_and_eval(expr)
+                stringify!($expr)
             }
         }
     }};
@@ -31,38 +30,62 @@ macro_rules! r {
     // so consider using `r!{{" .. "}}` syntax when whitespace is meaningful
     { $($expr:tt)+ } => {{
         {
-            let expr = stringify!($($expr)+);
-            $crate::lang::CallStack::default().parse_and_eval(expr)
+            stringify!($($expr)+)
         }
     }};
 }
 
 #[macro_export]
-macro_rules! r_expect {
-    // evaluate a single token directly
-    {{ $expr:tt }} => {{
-        {
-            // test if token is a string literal and evaluate directly
-            if let Some(s) = (&$expr as &dyn std::any::Any).downcast_ref::<&str>() {
-                let res  = $crate::lang::CallStack::default().parse_and_eval(s);
-                assert_eq!(res, r!{ true })
+macro_rules! formals {
+    ( $what:ident, $args:literal ) => {
+        lazy_static::lazy_static! {
+            pub static ref FORMALS: ExprList = {
+                use $crate::object::{Expr, ExprList};
 
-            // otherwise stringify token before evaluating
-            } else {
-                let expr = stringify!($expr);
-                let res  = $crate::lang::CallStack::default().parse_and_eval(expr);
-                assert_eq!(res, r!{ true })
+                let signature = $crate::r_parse! {{ $args }};
+                let Ok($crate::object::Expr::Call(_, signature)) = signature else {
+                    panic!("unexpected formal definition")
+                };
+
+                signature.into_iter()
+                    .map(|pair| match pair {
+                        (None, Expr::Symbol(name)) => (Some(name), Expr::Missing),
+                        pair => pair,
+                    })
+                    .collect::<ExprList>()
+            };
+        }
+
+        impl CallableFormals for $what {
+            fn formals(&self) -> ExprList {
+                FORMALS.clone()
             }
         }
-    }};
+    };
+}
 
-    // evaluate a token stream by first stringifying. This can affect whitespace,
-    // so consider using `r!{{" .. "}}` syntax when whitespace is meaningful
+#[macro_export]
+macro_rules! r_parse {
     { $($expr:tt)+ } => {{
-        {
-            let expr = stringify!($($expr)+);
-            let res  = $crate::lang::CallStack::default().parse_and_eval(expr);
-            assert_eq!(res, r!{ true })
-        }
+        let expr = $crate::r_macro_stringify!($($expr)+);
+        $crate::lang::CallStack::default().parse(expr)
+    }};
+}
+
+#[macro_export]
+macro_rules! r {
+    { $($expr:tt)+ } => {{
+        use $crate::context::Context;
+        ($crate::r_parse! { $($expr)+ })
+            .and_then(|x| $crate::lang::CallStack::default().eval_and_finalize(x))
+
+    }};
+}
+
+#[macro_export]
+macro_rules! r_expect {
+    { $($expr:tt)+ } => {{
+        let res = $crate::r! { $($expr)+ };
+        assert_eq!(res, r! { true })
     }};
 }


### PR DESCRIPTION
- reused some macro code to avoid copying complicated parsing code for each variant of `r!`, `r_expect!` and `r_parse!`
- Added `formals!` for creating a static formal definition and using it to implement `CallableFormals`, allows defining formals using R list syntax.
- converted `lazy_static!` to `std::sync::LazyLock`