### PR TITLE
Fix/substitute

### DIFF
--- a/src/callable/primitive/substitute.rs
+++ b/src/callable/primitive/substitute.rs
@@ -55,6 +55,13 @@ impl Callable for PrimitiveSubstitute {
             return internal_err!();
         };
 
+        let x = args.try_get_named("expr")?;
+        dbg!(&x.type_of());
+
+        if let Obj::Promise(value, ..) = args.try_get_named("expr")? {
+            dbg!(&value);
+        };
+
         let Obj::Promise(_, expr, _) = args.try_get_named("expr")? else {
             return internal_err!();
         };

--- a/src/callable/primitive/type_reflection.rs
+++ b/src/callable/primitive/type_reflection.rs
@@ -17,21 +17,7 @@ impl Callable for PrimitiveTypeOf {
         let mut args = Obj::List(args);
         let x = args.try_get_named("x")?.force(stack)?;
 
-        let t = match x {
-            Obj::Null => "null",
-            Obj::Vector(v) => match v {
-                Vector::Character(_) => "character",
-                Vector::Integer(_) => "integer",
-                Vector::Double(_) => "double",
-                Vector::Logical(_) => "logical",
-            },
-            Obj::List(_) => "list",
-            Obj::Expr(_) => "expression",
-            Obj::Promise(..) => "promise",
-            Obj::Function(..) => "function",
-            Obj::Environment(..) => "environment",
-        };
-        EvalResult::Ok(Obj::Vector(Vector::Character(vec![t.to_string()].into())))
+        EvalResult::Ok(Obj::Vector(Vector::Character(vec![x.type_of()].into())))
     }
 }
 

--- a/src/context/core.rs
+++ b/src/context/core.rs
@@ -88,7 +88,7 @@ pub trait Context: std::fmt::Debug + std::fmt::Display {
                             internal_err!()
                         }
                     }
-                    // Avoid creating a new closure just to point to another, just reuse it
+                    // Avoid creating a new promise just to point to another, just reuse it
                     (k, Expr::Symbol(s)) => match self.env().get(s.clone()) {
                         Ok(c @ Obj::Promise(..)) => {
                             let k = k.map_or(OptionNA::NA, OptionNA::Some);
@@ -109,12 +109,7 @@ pub trait Context: std::fmt::Debug + std::fmt::Display {
                         Ok(List::from(elem).iter_pairs())
                     }
                     (k, v) => {
-                        let k = k.map_or(OptionNA::NA, OptionNA::Some);
-                        if let Ok(elem) = self.eval(v) {
-                            Ok(List::from(vec![(k, elem)]).iter_pairs())
-                        } else {
-                            internal_err!()
-                        }
+                        Ok(List::from(vec![(k, Obj::Promise(None, v, self.env()))]).iter_pairs())
                     }
                 })
                 .collect::<Result<Vec<_>, _>>()?

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -247,6 +247,24 @@ impl Obj {
         }
     }
 
+    pub fn type_of(&self) -> String {
+        match self {
+            Obj::Null => "null",
+            Obj::Vector(v) => match v {
+                Vector::Character(_) => "character",
+                Vector::Integer(_) => "integer",
+                Vector::Double(_) => "double",
+                Vector::Logical(_) => "logical",
+            },
+            Obj::List(_) => "list",
+            Obj::Expr(_) => "expression",
+            Obj::Promise(..) => "promise",
+            Obj::Function(..) => "function",
+            Obj::Environment(..) => "environment",
+        }
+        .to_string()
+    }
+
     /// Used for `$`-assignment.
     pub fn try_set_named(&mut self, name: &str, value: Obj) -> EvalResult {
         match self {


### PR DESCRIPTION
We still need to properly handle the evaluation of ellipsis arguments:


```r
> (fn(...) list(...))(fn(x) x)
[[1]]
function(x) x @ <environment 0x60000092c3d8>
```